### PR TITLE
feat: Upgrade Droid workflows to Opus 4.7 frontier model + action v5

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -24,8 +24,11 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@v3
+        uses: Factory-AI/droid-action@v5
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
           automatic_security_review: true
+          review_model: claude-opus-4-7
+          reasoning_effort: high
+          security_model: claude-opus-4-7

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@v3
+        uses: Factory-AI/droid-action@v5
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          droid_args: "-m claude-opus-4-7 -r high"
+          fill_model: claude-opus-4-7


### PR DESCRIPTION
PR #1 merged with the default Factory workflows (action `@v3`, review_depth `deep` -> `gpt-5.2`). This PR pins everything to **Claude Opus 4.7**, the current #1 frontier model on Factory (April 2026), with high reasoning.

### Changes
- `droid.yml`: action upgraded to `@v5`; `@droid` tag runs pinned to `-m claude-opus-4-7 -r high` via `droid_args`; PR description fill also uses Opus 4.7.
- `droid-review.yml`: action upgraded to `@v5`; explicit `review_model: claude-opus-4-7`, `security_model: claude-opus-4-7`, `reasoning_effort: high`.

### Why
All autonomous remediation work queued in PR #2 depends on best-available reasoning for substrate-critical code review and execution. gpt-5.2 is strong but Opus 4.7 is ranked #1 for deep planning and architecture reviews.