### PR TITLE
feat(packets): Add wave-D remediation scaffolds (c, e.1, g, h)

### DIFF
--- a/docs/control-plane/implementation/packets/remediation/pkt-remediate-engine-version-0-1-0.md
+++ b/docs/control-plane/implementation/packets/remediation/pkt-remediate-engine-version-0-1-0.md
@@ -1,0 +1,71 @@
+# Remediation packet — Engine semver start at 0.1.0
+Version: 1.0
+Status: Authorized
+Task: Phase 4+ step 20 — post-reopen remediation wave D
+Artifact ID: pkt.remediate-engine-version-0.1.0.v1
+Prerequisite condition: (e.1) engine version direction
+Target repo: `agentic-engine`
+
+Plan-owner decision recorded at `canon-knowledgebase/post-reopen-decisions/condition-e-engine-version.md`.
+
+## Packet brief
+
+```json
+{
+  "packet_id": "pkt.remediate-engine-version-0.1.0.v1",
+  "title": "Bump agentic-engine workspace to 0.1.0 with spec-digest anchor",
+  "task_id": "P4p.step20.remediation.e1",
+  "objective": "Move every @canon/* workspace package from 0.0.0 to 0.1.0 and record the initial spec-digest anchor.",
+  "scope": [
+    "Update agentic-engine/package.json and every packages/*/package.json + workers/*/package.json to version 0.1.0.",
+    "Update any internal workspace: references to match.",
+    "Create docs/spec-digests/engine-0.1.0.md checkpoint with the content-hash anchor and the list of contracts/exports.json symbols at 0.1.0.",
+    "Update any repo-level version references in README if present.",
+    "Add CHANGELOG.md entry for 0.1.0 noting it as the first semver release after the audit-reopen remediation wave."
+  ],
+  "out_of_scope": [
+    "Publishing to npm.",
+    "Breaking-change introductions (this is a version-bump packet, not a breaking-change packet).",
+    "Canon/ quarantined draft state."
+  ],
+  "source_authority_refs": [
+    "canon-now.md condition (e)",
+    "canon-knowledgebase/post-reopen-decisions/condition-e-engine-version.md",
+    "CANON_PLAN_IMPACT_REPORT.md Section 6 row 7",
+    "AGENTIC_ENGINE_AUDIT_LOG.md X-010, X-015"
+  ],
+  "file_whitelist_ref": "wl.remediate-engine-version-0.1.0.v1",
+  "deliverables": [
+    "All package.json files bumped to 0.1.0",
+    "docs/spec-digests/engine-0.1.0.md",
+    "CHANGELOG.md entry",
+    "Draft carry-forward entry"
+  ],
+  "validation_hooks": [
+    { "hook_id": "vh.typecheck.pnpm" },
+    { "hook_id": "vh.test.pnpm" },
+    { "hook_id": "vh.build.pnpm" },
+    { "hook_id": "vh.spec-digest.present" },
+    { "hook_id": "vh.manual.acceptance" }
+  ],
+  "execution_mode": "factory_first",
+  "runtime": "github_actions_droid_or_cli_session",
+  "model": "claude-opus-4-7",
+  "reasoning_effort": "high"
+}
+```
+
+## File whitelist `wl.remediate-engine-version-0.1.0.v1`
+
+- `package.json` (root)
+- `packages/*/package.json`
+- `workers/*/package.json`
+- `docs/spec-digests/engine-0.1.0.md` (new)
+- `CHANGELOG.md`
+- `README.md` (only if it cites the version literally)
+
+## Completion signal
+
+- `jq -r '.version' packages/*/package.json` all return `0.1.0`.
+- `docs/spec-digests/engine-0.1.0.md` exists with content-hash anchor.
+- `pnpm build` green.

--- a/docs/control-plane/implementation/packets/remediation/pkt-remediate-peerdep-carveout.md
+++ b/docs/control-plane/implementation/packets/remediation/pkt-remediate-peerdep-carveout.md
@@ -1,0 +1,69 @@
+# Remediation packet — Intra-workspace peerDependency carve-out
+Version: 1.0
+Status: Authorized
+Task: Phase 4+ step 20 — post-reopen remediation wave D
+Artifact ID: pkt.remediate-peerdep-carveout.v1
+Prerequisite condition: (g) intra-workspace peerDependency carve-out
+Target repo: `Canon` (control-plane doc-only)
+
+Plan-owner decision recorded at `canon-knowledgebase/post-reopen-decisions/condition-g.md`.
+
+## Packet brief
+
+```json
+{
+  "packet_id": "pkt.remediate-peerdep-carveout.v1",
+  "title": "Amend phase-6-repo-package-architecture §6.1 to carve out intra-workspace peer-deps",
+  "task_id": "P4p.step20.remediation.g",
+  "objective": "Preserve the 'zero external runtime dependencies' invariant while explicitly permitting intra-workspace peer-dependencies between @canon/* packages.",
+  "scope": [
+    "Amend Canon/docs/control-plane/architecture/phase-6-repo-package-architecture-and-agent-execution-rules-pack.md §6.1 to add the carve-out paragraph.",
+    "Append carry-forward entry in master plan.",
+    "Update docs/control-plane/artifact-registry.seed.json if §6.1 is a registered artifact surface.",
+    "Update docs/control-plane/dependency-graph.seed.json if the amendment changes downstream artifact status."
+  ],
+  "out_of_scope": [
+    "Any agentic-engine code change.",
+    "Changing actual peer-dep declarations in agentic-engine packages.",
+    "Broadening the carve-out to third-party peer-deps."
+  ],
+  "source_authority_refs": [
+    "canon-now.md condition (g)",
+    "canon-knowledgebase/post-reopen-decisions/condition-g.md",
+    "CANON_PLAN_IMPACT_REPORT.md Section 6 row 8",
+    "AGENTIC_ENGINE_AUDIT_LOG.md X-029"
+  ],
+  "file_whitelist_ref": "wl.remediate-peerdep-carveout.v1",
+  "deliverables": [
+    "Amended §6.1 paragraph",
+    "Master-plan carry-forward entry",
+    "Synchronized registry/graph entries"
+  ],
+  "validation_hooks": [
+    { "hook_id": "vh.dependency.integrity" },
+    { "hook_id": "vh.consistency.cross-pack-review" },
+    { "hook_id": "vh.manual.acceptance" }
+  ],
+  "execution_mode": "factory_first",
+  "runtime": "cli_session_preferred",
+  "model": "claude-opus-4-7",
+  "reasoning_effort": "high",
+  "notes": [
+    "Control-plane only; no compiled code changes.",
+    "Run scripts/validators/validate_control_plane_integrity.py after the edit."
+  ]
+}
+```
+
+## File whitelist `wl.remediate-peerdep-carveout.v1`
+
+- `docs/control-plane/architecture/phase-6-repo-package-architecture-and-agent-execution-rules-pack.md`
+- `docs/control-plane/core/master-plan.md`
+- `docs/control-plane/artifact-registry.seed.json`
+- `docs/control-plane/dependency-graph.seed.json`
+
+## Completion signal
+
+- §6.1 contains the carve-out paragraph and preserves prior text.
+- Master-plan carry-forward entry appended.
+- `python3 scripts/validators/validate_control_plane_integrity.py` green.

--- a/docs/control-plane/implementation/packets/remediation/pkt-remediate-policy-matcher.md
+++ b/docs/control-plane/implementation/packets/remediation/pkt-remediate-policy-matcher.md
@@ -1,0 +1,71 @@
+# Remediation packet — Policy-matcher typed RulePattern
+Version: 1.0
+Status: Authorized (prerequisite decision recorded)
+Task: Phase 4+ step 20 — post-reopen remediation wave D
+Artifact ID: pkt.remediate-policy-matcher.v1
+Prerequisite condition: (c) policy-matcher pattern vs strict-equals
+Target repo: `agentic-engine`
+
+Plan-owner decision recorded at `canon-knowledgebase/post-reopen-decisions/condition-c.md` — Option A accepted.
+
+## Packet brief
+
+```json
+{
+  "packet_id": "pkt.remediate-policy-matcher.v1",
+  "title": "Ship typed RulePattern with glob/regex and replace strict-equals in policy paths",
+  "task_id": "P4p.step20.remediation.c",
+  "objective": "Replace strict-equals policy matching with a typed RulePattern tagged union supporting exact/glob/regex, with cached compilation and typed failure results.",
+  "scope": [
+    "Add packages/policy/src/rule-pattern.ts with RulePattern tagged union, matches() function, and cached regex compilation.",
+    "Update packages/policy/src/policy-matcher.ts to use matches() everywhere.",
+    "Add typed PolicyPatternCompileError for regex compilation failures.",
+    "Add packages/policy/src/__tests__/rule-pattern.test.ts covering exact + glob + regex + compile-failure paths.",
+    "Update contracts/exports.json to export RulePattern and matches additively."
+  ],
+  "out_of_scope": [
+    "Domain-pack rule definitions (they migrate later).",
+    "AuthorityScope restore factory (PKG-POL-011 is a separate ARCHITECTURE-CHANGE).",
+    "Canon/ quarantined draft state."
+  ],
+  "source_authority_refs": [
+    "canon-now.md condition (c)",
+    "canon-knowledgebase/post-reopen-decisions/condition-c.md",
+    "CANON_PLAN_IMPACT_REPORT.md Section 6 row 4",
+    "AGENTIC_ENGINE_AUDIT_LOG.md PKG-POL-001..005, PKG-POL-009, PKG-POL-014"
+  ],
+  "file_whitelist_ref": "wl.remediate-policy-matcher.v1",
+  "deliverables": [
+    "packages/policy/src/rule-pattern.ts (new)",
+    "Updated packages/policy/src/policy-matcher.ts",
+    "New regression test suite",
+    "Updated contracts/exports.json",
+    "Draft carry-forward entry"
+  ],
+  "validation_hooks": [
+    { "hook_id": "vh.typecheck.pnpm" },
+    { "hook_id": "vh.test.pnpm" },
+    { "hook_id": "vh.lint.no-strict-equals-in-policy-matchers" },
+    { "hook_id": "vh.manual.acceptance" }
+  ],
+  "execution_mode": "factory_first",
+  "runtime": "github_actions_droid_or_cli_session",
+  "model": "claude-opus-4-7",
+  "reasoning_effort": "high"
+}
+```
+
+## File whitelist `wl.remediate-policy-matcher.v1`
+
+- `packages/policy/src/rule-pattern.ts` (new)
+- `packages/policy/src/policy-matcher.ts`
+- `packages/policy/src/__tests__/rule-pattern.test.ts` (new)
+- `packages/policy/src/__tests__/policy-matcher.test.ts`
+- `contracts/exports.json`
+
+## Completion signal
+
+- `RulePattern` + `matches` exported additively.
+- No strict-equals string comparisons in `packages/policy/src/` outside `RulePattern` `kind: "exact"` branch.
+- Test matrix green across exact/glob/regex/compile-failure paths.
+- `pnpm typecheck` + `pnpm test` green.

--- a/docs/control-plane/implementation/packets/remediation/pkt-remediate-replay-compare-diff-semantics.md
+++ b/docs/control-plane/implementation/packets/remediation/pkt-remediate-replay-compare-diff-semantics.md
@@ -1,0 +1,70 @@
+# Remediation packet — Replay-compare id-aligned diff variant
+Version: 1.0
+Status: Authorized
+Task: Phase 4+ step 20 — post-reopen remediation wave D
+Artifact ID: pkt.remediate-replay-compare-diff-semantics.v1
+Prerequisite condition: (h) replay-compare diff-semantics
+Target repo: `agentic-engine`
+
+Plan-owner decision recorded at `canon-knowledgebase/post-reopen-decisions/condition-h.md`.
+
+## Packet brief
+
+```json
+{
+  "packet_id": "pkt.remediate-replay-compare-diff-semantics.v1",
+  "title": "Add id-aligned diff variant to replay-compare; document positional diff as historical",
+  "task_id": "P4p.step20.remediation.h",
+  "objective": "Ship diffByStableId() as the production replay-compare path while preserving the positional-index diff with a clear JSDoc warning.",
+  "scope": [
+    "Add workers/replay-compare/src/diff-by-stable-id.ts (or equivalent) implementing id-aligned diff.",
+    "Update workers/replay-compare/src/diff.ts JSDoc with the warning about positional-index semantics.",
+    "Update contracts/exports.json to export diffByStableId additively.",
+    "Add workers/replay-compare/src/__tests__/diff-by-stable-id.test.ts covering add/remove/modify/reorder.",
+    "Leave positional diff tests as-is."
+  ],
+  "out_of_scope": [
+    "Deleting positional diff (Option B was not accepted).",
+    "Migrating every caller to id-aligned (that is a separate downstream packet).",
+    "Changing the diff output schema beyond adding the new entry point."
+  ],
+  "source_authority_refs": [
+    "canon-now.md condition (h)",
+    "canon-knowledgebase/post-reopen-decisions/condition-h.md",
+    "CANON_PLAN_IMPACT_REPORT.md Section 6 row 9",
+    "AGENTIC_ENGINE_AUDIT_LOG.md WRK-RC-002"
+  ],
+  "file_whitelist_ref": "wl.remediate-replay-compare-diff-semantics.v1",
+  "deliverables": [
+    "New diff-by-stable-id module",
+    "Updated positional diff JSDoc",
+    "contracts/exports.json additions",
+    "New regression test suite",
+    "Draft carry-forward entry"
+  ],
+  "validation_hooks": [
+    { "hook_id": "vh.typecheck.pnpm" },
+    { "hook_id": "vh.test.pnpm" },
+    { "hook_id": "vh.manual.acceptance" }
+  ],
+  "execution_mode": "factory_first",
+  "runtime": "github_actions_droid_or_cli_session",
+  "model": "claude-opus-4-7",
+  "reasoning_effort": "high"
+}
+```
+
+## File whitelist `wl.remediate-replay-compare-diff-semantics.v1`
+
+- `workers/replay-compare/src/diff-by-stable-id.ts` (new)
+- `workers/replay-compare/src/diff.ts`
+- `workers/replay-compare/src/__tests__/diff-by-stable-id.test.ts` (new)
+- `workers/replay-compare/src/index.ts`
+- `contracts/exports.json`
+
+## Completion signal
+
+- `diffByStableId()` available on public exports.
+- Regression test matrix covers add/remove/modify/reorder with stable ids.
+- Positional diff JSDoc contains the warning.
+- `pnpm typecheck` + `pnpm test` green.


### PR DESCRIPTION
Adds four new remediation packet scaffolds authorized by plan-owner decisions recorded on 2026-04-23:

- `pkt.remediate-policy-matcher.v1` (condition c — typed RulePattern with glob/regex)
- `pkt.remediate-engine-version-0.1.0.v1` (condition e.1 — semver bump + spec-digest anchor)
- `pkt.remediate-peerdep-carveout.v1` (condition g — intra-workspace peer-dep carve-out, control-plane doc-only)
- `pkt.remediate-replay-compare-diff-semantics.v1` (condition h — id-aligned diff variant)

Per the plan-owner delegation rule added to `canon-now.md` on 2026-04-23: the agent defaults to the recommended option for non-direction-scale decisions. All four of these decisions are technical and do not change project direction.

Plan-owner decision records at `canon-knowledgebase/post-reopen-decisions/condition-{c,e-engine-version,g,h}.md`.

All packets pin `claude-opus-4-7 -r high`.