### PR TITLE
feat(packets): Add 4 packet scaffolds unblocked by DEC-RO-04 + DEC-RO-05

### DIFF
--- a/docs/control-plane/implementation/packets/remediation/pkt.add-proprietary-license.v1.md
+++ b/docs/control-plane/implementation/packets/remediation/pkt.add-proprietary-license.v1.md
@@ -1,0 +1,59 @@
+# pkt.add-proprietary-license.v1
+
+- **Packet ID**: `pkt.add-proprietary-license.v1`
+- **Authority**: DEC-RO-04 recorded at `canon-knowledgebase/post-reopen-decisions/condition-e-license.md`
+- **Carry-forward**: CF-0095
+- **Scope**: All 5 repos (Canon, agentic-engine, canon-apps, shared-environment, agentic-engine-history) + 1 doc update in Canon repo only
+- **Ordering**: Independent (no packet dependencies); safe to parallelize with wave-B packets after this lands
+- **Execution mode**: Autonomous via `droid-issue-exec.yml` on each repo. For cross-repo consistency, a single coordinator issue on `SaintFreddy/Canon` kicks off, packet requires the droid to open 5 PRs (1 per repo) via `gh api` on each target. Alternative simpler execution: open 5 separate issues, one per repo, each with a narrower scope.
+
+## Prerequisite
+
+DEC-RO-04 recorded (confirmed via in-repo `canon-knowledgebase/post-reopen-decisions/condition-e-license.md` — landed 2026-04-24 per CF-0095).
+
+## Goal
+
+Install the Proprietary LICENSE file at the root of every repo and reconcile the public-SDK phrasing in `AGENTIC_WORKFLOW.md §9` so the documented posture matches the recorded decision.
+
+## Exact LICENSE text
+
+Both new LICENSE files and reconciled AGENTIC_WORKFLOW.md must use the text verbatim from `condition-e-license.md`:
+
+```
+Copyright (c) 2026 SaintFreddy. All rights reserved.
+
+This source code and all associated files are proprietary and confidential.
+No license, express or implied, is granted to any person or entity for use,
+copy, modification, distribution, or creation of derivative works of this
+source code, in whole or in part, except as expressly authorized in writing
+by the copyright holder.
+```
+
+## File whitelist
+
+### In `SaintFreddy/Canon`:
+- `LICENSE` — create at repo root with exact text above. If a LICENSE file already exists, overwrite with the Proprietary text (any prior license was not accepted authority; the decision record is definitive).
+- `AGENTIC_WORKFLOW.md` — reconcile §9 L426 "public SDK posture" phrasing. Options:
+  - Variant A (preferred): mark the phrase as "aspirational, not current license posture under DEC-RO-04 (2026-04-24); see `canon-knowledgebase/post-reopen-decisions/condition-e-license.md` for the current posture and revisit conditions."
+  - Variant B: remove the phrasing entirely.
+  The packet executor must pick **Variant A** (preserves the aspiration for future revisit) unless §9 structure makes that awkward, in which case it picks Variant B and documents the choice in the PR body.
+
+### In `SaintFreddy/agentic-engine`, `SaintFreddy/canon-apps`, `SaintFreddy/shared-environment`, `SaintFreddy/agentic-engine-history`:
+- `LICENSE` — create at repo root with exact text above. Overwrite if present.
+
+### Also in Canon only:
+- `docs/control-plane/core/master-plan.md` — if it cites LICENSE status as "pending" or "aspirational public SDK", reconcile to reference DEC-RO-04 with the Proprietary posture.
+- `CANON_PLAN_IMPACT_REPORT.md` — append a row to §6 row 6 noting DEC-RO-04 landed on Option 4. This file is marked read-only in `canon-now.md`, so this is the ONE exception authorized by the decision record. The append must be a single new row at the end of §6's decision ledger, not a modification of existing rows.
+
+## Verification
+
+- `cat LICENSE` in each repo returns the exact text above, byte-for-byte.
+- `grep -c "public SDK posture" AGENTIC_WORKFLOW.md` in Canon either returns 0 (Variant B) or the remaining hits are inside the "aspirational / revisit" markup block (Variant A).
+- All 5 repos' build / test / typecheck suites remain green after the LICENSE file is added (LICENSE files do not affect builds).
+- Opens 5 separate PRs, 1 per repo. Canon's PR is the largest (LICENSE + AGENTIC_WORKFLOW + master-plan + impact-report). The other 4 are single-file PRs.
+
+## Forbidden
+
+- Do NOT license any file under any other posture.
+- Do NOT commit a SPDX header ("SPDX-License-Identifier: ...") in source files — that would contradict the proprietary posture. If existing files have SPDX headers, DO NOT modify them in this packet; raise a future packet for that cleanup.
+- Do NOT touch `canon-now.md`, `canon-knowledgebase/`, `AGENTIC_ENGINE_AUDIT_LOG.md`.

--- a/docs/control-plane/implementation/packets/remediation/pkt.quarantine-delete.v1.md
+++ b/docs/control-plane/implementation/packets/remediation/pkt.quarantine-delete.v1.md
@@ -1,0 +1,68 @@
+# pkt.quarantine-delete.v1
+
+- **Packet ID**: `pkt.quarantine-delete.v1`
+- **Authority**: DEC-RO-05 recorded at `canon-knowledgebase/post-reopen-decisions/condition-j.md`
+- **Carry-forward**: CF-0096
+- **Scope**: `SaintFreddy/Canon` control-plane only
+- **Ordering**: HARD-GATED on `pkt.quarantine-invariant-sweep.v1`'s PR merging to main. This packet MUST NOT execute before Packet A has landed.
+- **Execution mode**: Autonomous via `droid-issue-exec.yml`
+
+## Gating check (first step in execution, before any file modification)
+
+The executing droid MUST verify ALL of the following before proceeding:
+
+1. The file `canon-knowledgebase/post-reopen-decisions/condition-j.md` exists on current `main` and names this packet as "Packet B."
+2. A merged PR exists in `SaintFreddy/Canon` with title matching `Droid: [remediation] pkt.remediate-quarantine-invariant-sweep.v1` OR a PR whose body cites `pkt.quarantine-invariant-sweep.v1` and is in `merged` state. Use `gh pr list --repo SaintFreddy/Canon --state merged --search "quarantine-invariant-sweep"` to verify.
+3. The invariant-sweep PR's diff touched `docs/spec-digests/` files (confirming the sweep actually ran) and did NOT touch `Canon/packages`, `Canon/services`, or `Canon/workers` (confirming Packet A respected its scope).
+
+If ANY of these checks fail, the droid MUST stop, write `/tmp/droid-blocker.md` explaining which check failed, and exit cleanly per workflow rule 7.
+
+## Goal
+
+Physically remove the quarantined `Canon/packages/`, `Canon/services/`, `Canon/workers/` directories and reconcile phase-6 plan prose that still expects these directories to materialize in the Canon repo.
+
+## Execution steps
+
+1. **Pre-flight gate** (above). Stop if any check fails.
+
+2. **Remove directories**:
+   ```
+   git rm -rf Canon/packages
+   git rm -rf Canon/services
+   git rm -rf Canon/workers
+   ```
+   Note: the paths above are relative to the repo root. If the repo root does not have a top-level `Canon/` directory (i.e., the Canon repo's own root IS the Canon workspace), adjust to `git rm -rf packages services workers`. Detect correctly at execution time: check if a top-level `packages/` exists in the repo vs a nested `Canon/packages/`.
+
+3. **Reconcile phase-6 prose**. For each of the files below, grep for patterns that expect Canon to host packages/services/workers and reconcile with a statement referencing DEC-RO-05:
+   - `docs/control-plane/surfaces/phase-6-repo-package-architecture-and-agent-execution-rules-pack.md`
+   - `docs/control-plane/core/master-plan.md`
+   - `docs/control-plane/implementation/packets/**/*.md` (any that reference `Canon/packages|Canon/services|Canon/workers`)
+
+   Reconciliation format: replace the "will materialize in Canon under apps/packages/services/workers" phrasing with:
+   > *DEC-RO-05 (2026-04-24): Canon is control-plane + authority only; runtime lives in `agentic-engine`, `canon-apps`, `shared-environment`, `agentic-engine-history`. The quarantined draft roots (`Canon/packages/`, `Canon/services/`, `Canon/workers/`) were removed in `pkt.quarantine-delete.v1`. Git history preserves the 1,369 LOC for archaeology. See `canon-knowledgebase/post-reopen-decisions/condition-j.md`.*
+
+4. **Sanity checks** (must all pass):
+   - `ls Canon/packages Canon/services Canon/workers` returns "No such file or directory" (or equivalent for the chosen path).
+   - `git log --oneline -- Canon/packages` still returns non-empty output (confirms history is preserved).
+   - `grep -r "Canon/packages\|Canon/services\|Canon/workers" docs/ --exclude-dir=control-plane/implementation/packets/remediation` returns only the reconciliation-language additions from step 3 (no leftover expectations).
+   - `pnpm typecheck` remains green (nothing depended on these directories).
+
+5. **PR body must include**:
+   - List of files removed (count, not full enumeration).
+   - List of files reconciled (with quoted before/after snippets for the most important phase-6 prose changes).
+   - Confirmation that Packet A's PR is cited as prerequisite and is merged.
+   - Link to `canon-knowledgebase/post-reopen-decisions/condition-j.md`.
+
+## Forbidden
+
+- Do NOT execute before Packet A's PR is merged. The gating check at step 1 is hard-fail.
+- Do NOT delete any file outside the 3 quarantined directories.
+- Do NOT touch `canon-now.md`, `canon-knowledgebase/`, `AGENTIC_ENGINE_AUDIT_LOG.md`, `CANON_PLAN_IMPACT_REPORT.md`.
+- Do NOT modify `.gitignore` to hide the removal. The removal must be visible in git history.
+- Do NOT squash-force-push. Standard squash merge via auto-workflow is expected.
+
+## Post-merge follow-ups (outside this packet's scope)
+
+- Append CF-0098 to `canon-knowledgebase-layer-carry-forward.md` noting deletion complete + link to this PR. (Plan-owner or follow-up packet.)
+- Update `canon-now.md` "Constraint" paragraph: remove the clause that says "quarantined code must stay on disk" — replace with "quarantined code was removed 2026-04-XX per DEC-RO-05." (Plan-owner, since canon-now.md is human-owned.)
+- Verify no other repo has stale references to `Canon/packages|Canon/services|Canon/workers` (spot-check `agentic-engine`, `canon-apps`, `shared-environment`, `agentic-engine-history`).

--- a/docs/control-plane/implementation/packets/remediation/pkt.quarantine-invariant-sweep.v1.md
+++ b/docs/control-plane/implementation/packets/remediation/pkt.quarantine-invariant-sweep.v1.md
@@ -1,0 +1,89 @@
+# pkt.quarantine-invariant-sweep.v1
+
+- **Packet ID**: `pkt.quarantine-invariant-sweep.v1`
+- **Authority**: DEC-RO-05 recorded at `canon-knowledgebase/post-reopen-decisions/condition-j.md`
+- **Carry-forward**: CF-0096
+- **Scope**: `SaintFreddy/Canon` control-plane only
+- **Ordering**: PREREQUISITE for `pkt.quarantine-delete.v1`. The delete packet is hard-gated on this packet's PR landing on main.
+- **Execution mode**: Autonomous via `droid-issue-exec.yml`
+
+## Goal
+
+Before any physical removal of the quarantined draft directories (`Canon/packages/`, `Canon/services/`, `Canon/workers/`), extract every design invariant encoded in their `.mjs` contract-as-code files, identify which invariants are already captured in the post-reopen spec-digests, and port any uncaptured invariants as one-liners into the correct spec-digest file. This preserves design knowledge that git history alone doesn't make discoverable.
+
+## Factual basis (pre-audited during decision)
+
+- **Files in scope**: 11 `.mjs` files totaling 1,369 LOC across 3 directories:
+  - `Canon/packages/context-compiler-contracts/admitted-basis/index.mjs`
+  - `Canon/packages/environment-control-contracts/run-launch/index.mjs`
+  - `Canon/packages/event-provenance-contracts/run-lineage/index.mjs`
+  - `Canon/packages/model-gateway-contracts/chat-turn/index.mjs`
+  - `Canon/packages/shared-object-api/run-continuity/index.mjs`
+  - `Canon/packages/shared-object-schemas/run-and-source/index.mjs`
+  - `Canon/services/environment-shell-api/conversation-entry/index.mjs`
+  - `Canon/services/event-provenance/run-trace/index.mjs`
+  - `Canon/services/execution-control/run-dispatch/index.mjs`
+  - `Canon/services/model-gateway/chat-turn-execution/index.mjs`
+  - `Canon/workers/context-compiler/compile-run-context/index.mjs`
+- **Inbound imports**: zero from outside `Canon/` (audited).
+- **Ref-name overlap with control-plane**: zero (audited).
+- **Domain overlap with spec-digests**: present but under different naming.
+
+## Execution steps
+
+1. **Extract**: For each of the 11 `.mjs` files, parse out every `invariants: Object.freeze([...])` array. Record each invariant as: `{file, contract_catalog_id, invariant_text}`.
+
+2. **Map to spec digest**: For each extracted invariant, identify the target spec digest under `docs/spec-digests/` by subject:
+   - `context-compiler-*` → `docs/spec-digests/agentic-engine/engine-compiler.md`
+   - `model-gateway-*` → `docs/spec-digests/agentic-engine/engine-gateway.md`
+   - `event-provenance-*` → `docs/spec-digests/agentic-engine/engine-core.md` (or create a new provenance-specific digest if one does not exist; prefer adding to engine-core to avoid scope growth).
+   - `environment-control-*` / `environment-shell-api` → `docs/spec-digests/shared-environment/env-control.md`
+   - `shared-object-api` / `shared-object-schemas` → `docs/spec-digests/shared-environment/env-shared-objects.md`
+   - `execution-control` → `docs/spec-digests/shared-environment/env-governance.md`
+   - `context-compiler` worker → `docs/spec-digests/agentic-engine/engine-compiler.md`
+
+3. **De-duplicate against existing digest content**: For each invariant, grep the target digest for the key concept (e.g., "Explicit admitted inputs take precedence"). If the concept is already present, mark as "already-captured, skipping." Use semantic match; exact string match is not required. When unsure, port it.
+
+4. **Append under clearly-labelled subsection**: In each target spec digest, create (or append to) a subsection with this exact heading and body:
+
+   ```
+   ## Invariants (ported from quarantined pre-reopen contract catalogs, DEC-RO-05)
+
+   The following invariants were extracted from `Canon/{packages|services|workers}/<path>/index.mjs`
+   during the quarantine invariant-sweep packet (`pkt.quarantine-invariant-sweep.v1`,
+   authorized by DEC-RO-05 / CF-0096). The source files were subsequently removed by
+   `pkt.quarantine-delete.v1`; git history retains them for archaeology.
+
+   - *[invariant text]* — sourced from `Canon/<path>/index.mjs` contract `<contract_id>`.
+   - ...
+   ```
+
+5. **Do NOT delete the .mjs files**. This packet is read-and-append only.
+
+## Forbidden
+
+- Do NOT delete, rename, or modify any file under `Canon/packages/`, `Canon/services/`, `Canon/workers/`. That is Packet B's job.
+- Do NOT touch `canon-now.md`, `canon-knowledgebase/`, `AGENTIC_ENGINE_AUDIT_LOG.md`, `CANON_PLAN_IMPACT_REPORT.md` (authority records).
+- Do NOT invent invariants. Only port invariants that exist verbatim in the `.mjs` source.
+- Do NOT merge invariants from different source files into one bullet. One invariant = one bullet, with origin attribution.
+
+## Verification
+
+- `git diff --stat` shows changes ONLY in `docs/spec-digests/*.md` files.
+- `git diff -- Canon/packages Canon/services Canon/workers` is empty.
+- PR body lists every invariant found (categorized as "ported" vs "already-captured, skipped") with file attribution.
+- A final checklist confirms all 11 source files were scanned.
+- `pnpm typecheck` (if applicable in Canon) + Canon's spec-digest validation remain green.
+
+## PR body template
+
+The PR must include:
+- Summary of invariants found per source file
+- For each invariant: "ported to `X.md`" or "already-captured in `Y.md` section Z, skipped"
+- A statement confirming Packet B (`pkt.quarantine-delete.v1`) is now authorized to execute
+
+## Audit trail
+
+After this packet's PR merges:
+- Append CF-0097 to `canon-knowledgebase-layer-carry-forward.md` listing the invariants ported (can be appended separately by plan-owner or by a follow-up packet — not required inside this packet's PR).
+- `pkt.quarantine-delete.v1` becomes unblocked. Plan-owner may then re-comment `@droid run` on that packet's issue, or the workflow auto-advances if the issue body cites this PR's merge.

--- a/docs/control-plane/implementation/packets/remediation/pkt.remediate-docs-truth-readme-posture.v1.md
+++ b/docs/control-plane/implementation/packets/remediation/pkt.remediate-docs-truth-readme-posture.v1.md
@@ -1,0 +1,67 @@
+# pkt.remediate-docs-truth-readme-posture.v1
+
+- **Packet ID**: `pkt.remediate-docs-truth-readme-posture.v1`
+- **Authority**: combined — DEC-RO-04 (LICENSE) + multiple recorded decisions from CF-0093 / CF-0094 / CF-0095 / CF-0096 affecting documented posture
+- **Scope**: `SaintFreddy/agentic-engine` README.md + `docs-truth release-posture` guard + related posture-facing text
+- **Ordering**: Depends on `pkt.add-proprietary-license.v1` landing (so README can reference LICENSE). Independent of quarantine packets. Can parallelize with them once LICENSE lands.
+- **Execution mode**: Autonomous via `droid-issue-exec.yml`
+
+## Goal
+
+Bring the `agentic-engine` public-facing README and the docs-truth release-posture guard into alignment with the recorded decisions that emerged from the reopen remediation wave. The `pkt.remediate-engine-version-0.1.0.v1` PR noted that the docs-truth guard was currently red because of a prior README rewrite (commit `35a0252`) that did not reflect current posture; this packet fixes that honestly rather than suppressing the guard.
+
+## Authoritative posture this packet must encode
+
+- **LICENSE**: Proprietary / All Rights Reserved per DEC-RO-04. README LICENSE section must link to the newly-added `LICENSE` file at repo root; must not claim open-source posture.
+- **Engine version**: 0.1.0 per DEC-RO-03 / condition e.1. README must state current version as `0.1.0` and name the semver discipline.
+- **Platform Gate**: reopened per DEC-RO-0f / condition f; README must not claim Platform Gate "passed" unconditionally. Instead: "Platform Gate v1 reopened on 2026-04-23 with sub-gates PG-01.1 / PG-07.1 / PG-10.1; see Canon's `docs/control-plane/architecture/phase-3-platform-gate-spec-and-exit-audit.md`."
+- **Clock / TimeProvider**: engine owns `Clock` interface per DEC-RO-0a / condition a. README's "Design" section should mention injected time source.
+- **Credential scope**: engine-owned `CredentialProvider` + hardened `validateCredentialScope` per DEC-RO-0b / condition b (sub B-1). README's security section should reflect this.
+- **Tool sandbox**: `spawnToolSandboxWorker` forks real Node child (per DEC-RO-0b sub B-2); `InProcessToolRunner` is the explicit dev-mode alternative. README's capabilities section should accurately describe both.
+- **Replay compare**: id-aligned `diffByStableId` is production path per DEC-RO-0h / condition h; positional `diff` retained with warning.
+- **Peer dep carve-out**: phase-6 §6.1 amended per DEC-RO-0g / condition g; README's "Dependencies" section (if any) should be consistent.
+- **Quarantine**: once `pkt.quarantine-delete.v1` has merged, README must not imply Canon hosts implementation. This packet should land after that deletion to keep posture consistent.
+
+## File whitelist
+
+- `README.md` at `SaintFreddy/agentic-engine` root
+- `tests/docs-truth/release-posture.test.ts` (or equivalent path of the docs-truth guard test — search for the test file that failed in `pkt.remediate-engine-version-0.1.0.v1`'s verification output)
+- `docs/release-posture.md` (if present; Canon's `docs/control-plane/` references its existence)
+
+Do NOT modify:
+- Any source under `packages/` or `workers/`
+- `contracts/exports.json` / `contracts/imports.json` (that's engine-version packet scope)
+- `canon-now.md`, `canon-knowledgebase/`, etc. (authority)
+
+## Execution steps
+
+1. **Read the authority set** from `canon-knowledgebase/post-reopen-decisions/condition-{a,b,c,d,e-engine-version,e-license,f,g,h,i}.md` + `frozenat-hash-inclusion.md` + `condition-j.md`.
+2. **Draft the new README** section-by-section so each section states a single unambiguous posture aligned with the recorded decisions. Do NOT over-claim capability; do NOT understate. The README is a public face for the proprietary engine, so it should be confident without promising features that aren't there.
+3. **Update the docs-truth guard test** to assert the new README's truth-claims against the recorded authority. Specifically:
+   - The test should assert README cites LICENSE=Proprietary (grep for the exact Proprietary text).
+   - The test should assert README states engine version 0.1.0 (grep for "0.1.0").
+   - The test should assert README references Platform Gate v1 reopen status (grep for "reopen" or "PG-01.1").
+   - Any other posture items the existing test was checking.
+4. **Run the guard** — `pnpm test tests/docs-truth/release-posture.test.ts` should now be green.
+5. **Run the full test suite** — `pnpm test && pnpm typecheck && pnpm build` should all be green.
+
+## Forbidden
+
+- Do NOT weaken the docs-truth guard to make it pass artificially. Guard changes must only reflect the new truth posture.
+- Do NOT add marketing fluff. The README is the public posture of a proprietary engine; be factual.
+- Do NOT reference external contributors, community, or open-source pathways — DEC-RO-04 forecloses that.
+- Do NOT reference `Canon/packages|services|workers` as live implementation — per DEC-RO-05 they are scheduled for deletion.
+
+## Verification
+
+- `cat README.md | head -80` shows updated LICENSE, version, Platform Gate posture.
+- `pnpm test tests/docs-truth/release-posture.test.ts` green.
+- `pnpm test && pnpm typecheck && pnpm build` green.
+- PR body names which decisions it encodes, section-by-section.
+
+## Prerequisite checks (first step in droid exec)
+
+1. LICENSE file exists at `agentic-engine` repo root (confirms `pkt.add-proprietary-license.v1` has landed).
+2. `package.json`'s `version` field is `0.1.0` (confirms `pkt.remediate-engine-version-0.1.0.v1` has landed; this has already happened as of 2026-04-24).
+
+If LICENSE file is missing, stop and blocker-out pointing at `pkt.add-proprietary-license.v1`.


### PR DESCRIPTION
Adds the 4 packet scaffolds authorized by the newly-recorded plan-owner decisions:

### License + quarantine packets (from DEC-RO-04 + DEC-RO-05 / CF-0095 + CF-0096)
- `pkt.add-proprietary-license.v1` — add Proprietary LICENSE file to 5 repos + reconcile AGENTIC_WORKFLOW.md §9 public-SDK phrasing
- `pkt.quarantine-invariant-sweep.v1` — extract + port invariants from 11 .mjs files (1,369 LOC) into spec-digests. NO deletion.
- `pkt.quarantine-delete.v1` — hard-gated on the sweep packet; physical `git rm -r` + phase-6 prose reconciliation
- `pkt.remediate-docs-truth-readme-posture.v1` — align agentic-engine README + docs-truth guard with all recorded decisions (engine-version packet left it red; this honestly fixes the guard rather than suppressing it)

### Gating
- Quarantine-delete's first execution step is a hard gate on the invariant-sweep PR being merged. The droid will fail-closed with a blocker if the sweep hasn't landed.
- README posture packet has a pre-flight check that LICENSE file exists in agentic-engine (confirms LICENSE packet has landed).

### Order for opening issues
1. LICENSE first (independent, 5 repos parallelize naturally)
2. Quarantine invariant sweep (Canon only)
3. Quarantine delete (Canon only — after sweep PR merges)
4. README posture (agentic-engine — after LICENSE merges in agentic-engine)