### PR TITLE
chore(archive): One-time preservation of pre-reopen quarantine under docs/control-plane/archive/

### DIFF
--- a/docs/control-plane/archive/quarantine-pre-reopen/README.md
+++ b/docs/control-plane/archive/quarantine-pre-reopen/README.md
@@ -1,0 +1,43 @@
+# Quarantine archive — pre-reopen contract-as-code (DEC-RO-05)
+
+This directory preserves 11 `.mjs` contract-as-code files (1,369 LOC) from the
+pre-reopen Canon workspace that were never committed to the remote `main`
+branch. They lived only in the plan-owner's local workspace as "quarantined
+draft state" and were archived here as a one-time preservation commit before
+local deletion under DEC-RO-05 (2026-04-24).
+
+See:
+- `canon-knowledgebase/post-reopen-decisions/condition-j.md` — the decision record
+- `canon-knowledgebase/canon-knowledgebase-layer-carry-forward.md` CF-0096 — carry-forward entry
+- `docs/control-plane/implementation/packets/remediation/pkt.quarantine-invariant-sweep.v1.md` — the invariant-sweep packet that reads from this archive and ports invariants into spec-digests
+
+## Structure
+
+- `packages/` — 6 contract-package catalogs (each under its own subdirectory with `index.mjs`)
+- `services/` — 4 service execution catalogs
+- `workers/` — 1 worker execution catalog
+
+## Nature of the content
+
+Each `index.mjs` exports a frozen JS catalog encoding:
+- `contract_ref` strings (e.g., `contract.context-compiler.admitted-basis.compile-run-context.v1`)
+- Field schemas
+- Required-field sets
+- Invariants (the primary preservation target for the invariant-sweep packet)
+
+The ref naming format in these files does NOT match the post-reopen
+`docs/control-plane/artifact-registry.seed.json` format. These are parallel
+pre-reopen contract artifacts that were superseded by the control-plane
+registry + spec-digests system.
+
+## Do not import
+
+Nothing in the live Canon or satellite repos imports from this archive. These
+files are for design archaeology only. Do not wire them into any build,
+tsconfig, package.json, or runtime.
+
+## Reconstruction
+
+Git history before this commit has no trace of these files (they were
+uncommitted local workspace artifacts). This commit is the first and only
+time they appear in Canon's git history.

--- a/docs/control-plane/archive/quarantine-pre-reopen/packages/context-compiler-contracts/admitted-basis/index.mjs
+++ b/docs/control-plane/archive/quarantine-pre-reopen/packages/context-compiler-contracts/admitted-basis/index.mjs
@@ -1,0 +1,136 @@
+import { runAndSourceRefs } from "../../shared-object-schemas/run-and-source/index.mjs"
+
+const refField = Object.freeze({ type: "ref", nullable: false })
+const optionalRefField = Object.freeze({ type: "ref", nullable: true })
+const stringField = Object.freeze({ type: "string", nullable: false })
+const optionalStringField = Object.freeze({ type: "string", nullable: true })
+const refArrayField = Object.freeze({ type: "array", items: { type: "ref" }, default: [] })
+
+export const ADMITTED_BASIS_CONTRACT_VERSION = "1.0.0"
+
+export const admittedBasisRefs = Object.freeze({
+  compileRunContextCommand: "contract.context-compiler.admitted-basis.compile-run-context.v1",
+  admittedBasisRecord: "contract.context-compiler.admitted-basis.record.v1",
+  compileRunContextResult: "contract.context-compiler.admitted-basis.result.v1",
+})
+
+export const compileRunContextCommand = Object.freeze({
+  contract_ref: admittedBasisRefs.compileRunContextCommand,
+  kind: "job_contract",
+  shared_object_refs: Object.freeze([
+    runAndSourceRefs.run,
+    runAndSourceRefs.runInputSnapshot,
+    runAndSourceRefs.sourceReference,
+  ]),
+  description:
+    "Compiler request for freezing the R1 admitted basis from explicit inputs before model invocation.",
+  required_fields: [
+    "run_ref",
+    "thread_ref",
+    "input_snapshot_ref",
+    "requested_source_ref_ids",
+  ],
+  fields: Object.freeze({
+    run_ref: refField,
+    thread_ref: refField,
+    input_snapshot_ref: refField,
+    requested_source_ref_ids: refArrayField,
+    evidence_pack_ref: optionalRefField,
+    explicit_memory_refs: refArrayField,
+    explicit_canon_refs: refArrayField,
+    authority_scope_ref: optionalRefField,
+    branch_ref: optionalRefField,
+    provider_session_hint: Object.freeze({ type: "string", nullable: true }),
+    compaction_policy: optionalStringField,
+  }),
+  invariants: Object.freeze([
+    "Explicit admitted inputs take precedence over fallback lane selection.",
+    "Provider continuity hints are advisory only and never become the replay basis.",
+  ]),
+})
+
+export const admittedBasisRecord = Object.freeze({
+  contract_ref: admittedBasisRefs.admittedBasisRecord,
+  kind: "record_contract",
+  shared_object_refs: Object.freeze([
+    runAndSourceRefs.contextPackSnapshot,
+    runAndSourceRefs.sourceReference,
+  ]),
+  description:
+    "Frozen admitted-basis record kept behind compact inspection and exact replay for one R1 run.",
+  required_fields: [
+    "admitted_basis_ref",
+    "run_ref",
+    "input_snapshot_ref",
+    "context_pack_ref",
+    "memory_lane",
+    "canon_lane",
+    "authority_scope_ref",
+  ],
+  fields: Object.freeze({
+    admitted_basis_ref: refField,
+    run_ref: refField,
+    input_snapshot_ref: refField,
+    context_pack_ref: refField,
+    evidence_pack_ref: optionalRefField,
+    included_source_ref_ids: refArrayField,
+    excluded_source_items: Object.freeze({ type: "array", items: { type: "object" }, default: [] }),
+    memory_lane: Object.freeze({
+      type: "object",
+      required_fields: ["basis_origin", "included_refs", "excluded_items"],
+      fields: Object.freeze({
+        basis_origin: Object.freeze({ type: "string", enum: ["explicit", "fallback", "absent"] }),
+        included_refs: refArrayField,
+        excluded_items: Object.freeze({ type: "array", items: { type: "object" }, default: [] }),
+      }),
+    }),
+    canon_lane: Object.freeze({
+      type: "object",
+      required_fields: ["basis_origin", "mode", "included_refs", "excluded_items"],
+      fields: Object.freeze({
+        basis_origin: Object.freeze({ type: "string", enum: ["explicit", "fallback", "absent"] }),
+        mode: optionalStringField,
+        included_refs: refArrayField,
+        excluded_items: Object.freeze({ type: "array", items: { type: "object" }, default: [] }),
+      }),
+    }),
+    authority_scope_ref: refField,
+    branch_ref: optionalRefField,
+    compaction_notes: Object.freeze({ type: "array", items: { type: "string" }, default: [] }),
+  }),
+})
+
+export const compileRunContextResult = Object.freeze({
+  contract_ref: admittedBasisRefs.compileRunContextResult,
+  kind: "job_result_contract",
+  shared_object_refs: Object.freeze([
+    runAndSourceRefs.contextPackSnapshot,
+    runAndSourceRefs.proofBundleSummary,
+  ]),
+  description:
+    "Compiler result exposing the frozen context-pack ref and compact admitted-basis summary needed by R1 inspection and replay.",
+  required_fields: ["run_ref", "context_pack_ref", "admitted_basis_ref", "frozen"],
+  fields: Object.freeze({
+    run_ref: refField,
+    context_pack_ref: refField,
+    admitted_basis_ref: refField,
+    frozen: Object.freeze({ type: "boolean", const: true }),
+    compact_summary_sections: Object.freeze({
+      type: "array",
+      items: { type: "string" },
+      default: ["sources", "memory", "canon", "authority"],
+    }),
+  }),
+})
+
+export const admittedBasisContractCatalog = Object.freeze({
+  package_id: "pkg.context-compiler-contracts.admitted-basis",
+  package_version: ADMITTED_BASIS_CONTRACT_VERSION,
+  contracts: Object.freeze({
+    compile_run_context: compileRunContextCommand,
+    admitted_basis_record: admittedBasisRecord,
+    compile_run_context_result: compileRunContextResult,
+  }),
+})
+
+export default admittedBasisContractCatalog

--- a/docs/control-plane/archive/quarantine-pre-reopen/packages/environment-control-contracts/run-launch/index.mjs
+++ b/docs/control-plane/archive/quarantine-pre-reopen/packages/environment-control-contracts/run-launch/index.mjs
@@ -1,0 +1,159 @@
+import { runAndSourceRefs } from "../../shared-object-schemas/run-and-source/index.mjs"
+
+const refField = Object.freeze({ type: "ref", nullable: false })
+const optionalRefField = Object.freeze({ type: "ref", nullable: true })
+const stringField = Object.freeze({ type: "string", nullable: false })
+const refArrayField = Object.freeze({ type: "array", items: { type: "ref" }, default: [] })
+
+export const RUN_LAUNCH_CONTRACT_VERSION = "1.0.0"
+
+export const runLaunchRefs = Object.freeze({
+  startConversationRunCommand: "contract.environment-control.run-launch.start-conversation.v1",
+  resumeConversationRunCommand: "contract.environment-control.run-launch.resume-conversation.v1",
+  rerunConversationRunCommand: "contract.environment-control.run-launch.rerun-conversation.v1",
+  runLaunchAccepted: "contract.environment-control.run-launch.accepted.v1",
+  runLaunchRejected: "contract.environment-control.run-launch.rejected.v1",
+})
+
+export const startConversationRunCommand = Object.freeze({
+  contract_ref: runLaunchRefs.startConversationRunCommand,
+  kind: "command_contract",
+  shared_object_refs: Object.freeze([
+    runAndSourceRefs.threadLine,
+    runAndSourceRefs.runInputSnapshot,
+    runAndSourceRefs.sourceReference,
+  ]),
+  description:
+    "Typed request for starting a new or continuing R1 chat turn as a bounded run without relying on ambient provider-managed transcript state.",
+  required_fields: [
+    "launch_mode",
+    "run_class",
+    "input_snapshot_ref",
+    "thread_ref",
+    "user_turn_text",
+  ],
+  fields: Object.freeze({
+    launch_mode: Object.freeze({ type: "string", enum: ["new_thread", "continue_thread"] }),
+    run_class: Object.freeze({ type: "string", enum: ["synthesize", "extract"] }),
+    thread_ref: refField,
+    input_snapshot_ref: refField,
+    requested_source_ref_ids: refArrayField,
+    user_turn_text: stringField,
+    objective_spec: Object.freeze({ type: "object", allow_additional_fields: true }),
+    authority_scope_ref: optionalRefField,
+    contract_ref: optionalRefField,
+    provider_session_hint: Object.freeze({ type: "string", nullable: true }),
+  }),
+  invariants: Object.freeze([
+    "The provider session hint is optional and non-durable.",
+    "Every accepted launch routes into a new run identity rather than mutating prior assistant truth.",
+  ]),
+})
+
+export const resumeConversationRunCommand = Object.freeze({
+  contract_ref: runLaunchRefs.resumeConversationRunCommand,
+  kind: "command_contract",
+  shared_object_refs: Object.freeze([
+    runAndSourceRefs.threadLine,
+    runAndSourceRefs.run,
+    runAndSourceRefs.contextPackSnapshot,
+  ]),
+  description:
+    "Typed request for continuing a thread from explicit shared refs after provider continuity is lost or intentionally absent.",
+  required_fields: [
+    "thread_ref",
+    "prior_run_ref",
+    "input_snapshot_ref",
+    "since_last_run_ref",
+  ],
+  fields: Object.freeze({
+    thread_ref: refField,
+    prior_run_ref: refField,
+    input_snapshot_ref: refField,
+    since_last_run_ref: optionalRefField,
+    latest_context_pack_ref: optionalRefField,
+    requested_source_ref_ids: refArrayField,
+    provider_session_hint: Object.freeze({ type: "string", nullable: true }),
+  }),
+  invariants: Object.freeze([
+    "Resume behavior remains valid even when provider continuity is unavailable.",
+  ]),
+})
+
+export const rerunConversationRunCommand = Object.freeze({
+  contract_ref: runLaunchRefs.rerunConversationRunCommand,
+  kind: "command_contract",
+  shared_object_refs: Object.freeze([
+    runAndSourceRefs.run,
+    runAndSourceRefs.runInputSnapshot,
+    runAndSourceRefs.contextPackSnapshot,
+  ]),
+  description:
+    "Typed request for regenerate-or-rerun behavior that carries forward explicit frozen basis links while creating a new run identity.",
+  required_fields: ["thread_ref", "prior_run_ref", "input_snapshot_ref", "rerun_reason"],
+  fields: Object.freeze({
+    thread_ref: refField,
+    prior_run_ref: refField,
+    input_snapshot_ref: refField,
+    prior_context_pack_ref: optionalRefField,
+    rerun_reason: stringField,
+    requested_source_ref_ids: refArrayField,
+  }),
+  invariants: Object.freeze([
+    "Rerun never reuses the prior run_id.",
+  ]),
+})
+
+export const runLaunchAccepted = Object.freeze({
+  contract_ref: runLaunchRefs.runLaunchAccepted,
+  kind: "event_contract",
+  shared_object_refs: Object.freeze([runAndSourceRefs.run, runAndSourceRefs.threadLine]),
+  description:
+    "Accepted launch receipt returned once the environment-control layer allocates a new run and dispatch path.",
+  required_fields: ["run_ref", "thread_ref", "status", "dispatch_ref"],
+  fields: Object.freeze({
+    run_ref: refField,
+    thread_ref: refField,
+    status: Object.freeze({ type: "string", enum: ["prepared", "admitted"] }),
+    dispatch_ref: refField,
+    provider_session_hint_consumed: Object.freeze({ type: "boolean", nullable: false }),
+  }),
+})
+
+export const runLaunchRejected = Object.freeze({
+  contract_ref: runLaunchRefs.runLaunchRejected,
+  kind: "event_contract",
+  shared_object_refs: Object.freeze([runAndSourceRefs.threadLine]),
+  description:
+    "Explicit blocked launch result used when the request cannot be admitted without widening scope or violating the R1 continuity contract.",
+  required_fields: ["thread_ref", "blocked_reason", "provider_session_required"],
+  fields: Object.freeze({
+    thread_ref: refField,
+    blocked_reason: stringField,
+    provider_session_required: Object.freeze({ type: "boolean", const: false }),
+    missing_ref_ids: refArrayField,
+  }),
+})
+
+export const runLaunchContractCatalog = Object.freeze({
+  package_id: "pkg.environment-control-contracts.run-launch",
+  package_version: RUN_LAUNCH_CONTRACT_VERSION,
+  command_refs: Object.freeze({
+    start_conversation_run: startConversationRunCommand.contract_ref,
+    resume_conversation_run: resumeConversationRunCommand.contract_ref,
+    rerun_conversation_run: rerunConversationRunCommand.contract_ref,
+  }),
+  result_refs: Object.freeze({
+    accepted: runLaunchAccepted.contract_ref,
+    rejected: runLaunchRejected.contract_ref,
+  }),
+  contracts: Object.freeze({
+    start_conversation_run: startConversationRunCommand,
+    resume_conversation_run: resumeConversationRunCommand,
+    rerun_conversation_run: rerunConversationRunCommand,
+    launch_accepted: runLaunchAccepted,
+    launch_rejected: runLaunchRejected,
+  }),
+})
+
+export default runLaunchContractCatalog

--- a/docs/control-plane/archive/quarantine-pre-reopen/packages/event-provenance-contracts/run-lineage/index.mjs
+++ b/docs/control-plane/archive/quarantine-pre-reopen/packages/event-provenance-contracts/run-lineage/index.mjs
@@ -1,0 +1,125 @@
+import { runAndSourceRefs } from "../../shared-object-schemas/run-and-source/index.mjs"
+
+const refField = Object.freeze({ type: "ref", nullable: false })
+const optionalRefField = Object.freeze({ type: "ref", nullable: true })
+const stringField = Object.freeze({ type: "string", nullable: false })
+const refArrayField = Object.freeze({ type: "array", items: { type: "ref" }, default: [] })
+
+export const RUN_LINEAGE_CONTRACT_VERSION = "1.0.0"
+
+export const runLineageRefs = Object.freeze({
+  runLifecycleEvent: "contract.event-provenance.run-lineage.lifecycle-event.v1",
+  sourceResolutionEvent: "contract.event-provenance.run-lineage.source-resolution-event.v1",
+  resumeContinuityEvent: "contract.event-provenance.run-lineage.resume-event.v1",
+  runLineageQuery: "contract.event-provenance.run-lineage.query.v1",
+})
+
+export const runLifecycleEvent = Object.freeze({
+  contract_ref: runLineageRefs.runLifecycleEvent,
+  kind: "event_contract",
+  shared_object_refs: Object.freeze([
+    runAndSourceRefs.run,
+    runAndSourceRefs.contextPackSnapshot,
+    runAndSourceRefs.proofBundleSummary,
+  ]),
+  description:
+    "Append-only run lifecycle event envelope for prepared, admitted, executing, and terminal R1 run state transitions.",
+  required_fields: ["event_ref", "event_type", "run_ref", "thread_ref", "occurred_at"],
+  fields: Object.freeze({
+    event_ref: refField,
+    event_type: Object.freeze({
+      type: "string",
+      enum: ["run_prepared", "run_admitted", "run_executing", "run_completed", "run_failed", "run_cancelled"],
+    }),
+    run_ref: refField,
+    thread_ref: refField,
+    input_snapshot_ref: optionalRefField,
+    context_pack_ref: optionalRefField,
+    proof_bundle_ref: optionalRefField,
+    state_delta_ref: optionalRefField,
+    occurred_at: stringField,
+  }),
+  invariants: Object.freeze([
+    "Lifecycle events are append-only and reconstructable after provider continuity loss.",
+  ]),
+})
+
+export const sourceResolutionEvent = Object.freeze({
+  contract_ref: runLineageRefs.sourceResolutionEvent,
+  kind: "event_contract",
+  shared_object_refs: Object.freeze([runAndSourceRefs.sourceReference, runAndSourceRefs.run]),
+  description:
+    "Append-only source lineage event for attachments, admissions, exclusions, and source-chip citations.",
+  required_fields: ["event_ref", "event_type", "run_ref", "source_ref", "occurred_at"],
+  fields: Object.freeze({
+    event_ref: refField,
+    event_type: Object.freeze({
+      type: "string",
+      enum: ["source_attached", "source_included", "source_excluded", "source_cited"],
+    }),
+    run_ref: refField,
+    source_ref: refField,
+    source_region_ref: optionalRefField,
+    lineage_reason: stringField,
+    occurred_at: stringField,
+  }),
+})
+
+export const resumeContinuityEvent = Object.freeze({
+  contract_ref: runLineageRefs.resumeContinuityEvent,
+  kind: "event_contract",
+  shared_object_refs: Object.freeze([runAndSourceRefs.threadLine, runAndSourceRefs.run]),
+  description:
+    "Append-only continuity event for resume-basis generation and provider-continuity loss handling.",
+  required_fields: ["event_ref", "event_type", "thread_ref", "occurred_at"],
+  fields: Object.freeze({
+    event_ref: refField,
+    event_type: Object.freeze({
+      type: "string",
+      enum: ["resume_basis_generated", "provider_continuity_lost", "thread_resumed"],
+    }),
+    thread_ref: refField,
+    prior_run_ref: optionalRefField,
+    next_run_ref: optionalRefField,
+    since_last_run_ref: optionalRefField,
+    provider_continuity_required: Object.freeze({ type: "boolean", const: false }),
+    occurred_at: stringField,
+  }),
+})
+
+export const runLineageQuery = Object.freeze({
+  contract_ref: runLineageRefs.runLineageQuery,
+  kind: "query_contract",
+  shared_object_refs: Object.freeze([runAndSourceRefs.run, runAndSourceRefs.threadLine]),
+  description:
+    "Typed lineage query over run lifecycle, source resolution, and resume continuity events.",
+  required_fields: [],
+  fields: Object.freeze({
+    thread_ref: optionalRefField,
+    run_ref: optionalRefField,
+    event_types: Object.freeze({ type: "array", items: { type: "string" }, default: [] }),
+    since_event_ref: optionalRefField,
+    limit: Object.freeze({ type: "number", minimum: 1, maximum: 200 }),
+  }),
+  invariants: Object.freeze([
+    "Lineage queries reconstruct state from append-only events rather than implicit transcript history.",
+  ]),
+})
+
+export const runLineageContractCatalog = Object.freeze({
+  package_id: "pkg.event-provenance-contracts.run-lineage",
+  package_version: RUN_LINEAGE_CONTRACT_VERSION,
+  contracts: Object.freeze({
+    run_lifecycle_event: runLifecycleEvent,
+    source_resolution_event: sourceResolutionEvent,
+    resume_continuity_event: resumeContinuityEvent,
+    run_lineage_query: runLineageQuery,
+  }),
+  event_groups: Object.freeze({
+    run_lifecycle: runLifecycleEvent.contract_ref,
+    source_resolution: sourceResolutionEvent.contract_ref,
+    resume_continuity: resumeContinuityEvent.contract_ref,
+  }),
+})
+
+export default runLineageContractCatalog

--- a/docs/control-plane/archive/quarantine-pre-reopen/packages/model-gateway-contracts/chat-turn/index.mjs
+++ b/docs/control-plane/archive/quarantine-pre-reopen/packages/model-gateway-contracts/chat-turn/index.mjs
@@ -1,0 +1,110 @@
+import { runAndSourceRefs } from "../../shared-object-schemas/run-and-source/index.mjs"
+
+const refField = Object.freeze({ type: "ref", nullable: false })
+const optionalRefField = Object.freeze({ type: "ref", nullable: true })
+const stringField = Object.freeze({ type: "string", nullable: false })
+const optionalStringField = Object.freeze({ type: "string", nullable: true })
+const refArrayField = Object.freeze({ type: "array", items: { type: "ref" }, default: [] })
+
+export const CHAT_TURN_CONTRACT_VERSION = "1.0.0"
+
+export const chatTurnRefs = Object.freeze({
+  chatTurnRequest: "contract.model-gateway.chat-turn.request.v1",
+  sourceAttribution: "contract.model-gateway.chat-turn.source-attribution.v1",
+  chatTurnResult: "contract.model-gateway.chat-turn.result.v1",
+  chatTurnFailure: "contract.model-gateway.chat-turn.failure.v1",
+})
+
+export const chatTurnRequest = Object.freeze({
+  contract_ref: chatTurnRefs.chatTurnRequest,
+  kind: "gateway_request_contract",
+  shared_object_refs: Object.freeze([
+    runAndSourceRefs.run,
+    runAndSourceRefs.contextPackSnapshot,
+    runAndSourceRefs.sourceReference,
+  ]),
+  description:
+    "Typed provider-facing request for one bounded R1 assistant answer built over an already frozen admitted basis.",
+  required_fields: ["run_ref", "thread_ref", "context_pack_ref", "turn_messages"],
+  fields: Object.freeze({
+    run_ref: refField,
+    thread_ref: refField,
+    context_pack_ref: refField,
+    turn_messages: Object.freeze({ type: "array", items: { type: "object" }, min_items: 1 }),
+    allowed_source_ref_ids: refArrayField,
+    output_mode: Object.freeze({ type: "string", enum: ["assistant_message"] }),
+    citation_mode: Object.freeze({ type: "string", enum: ["source_chip_required"] }),
+    provider_session_hint: Object.freeze({ type: "string", nullable: true }),
+    model_profile_ref: optionalRefField,
+  }),
+  invariants: Object.freeze([
+    "The gateway consumes frozen admitted basis and may not rebuild truth from transcript continuity.",
+    "Provider session hints may assist UX but do not become durable run truth.",
+  ]),
+})
+
+export const sourceAttribution = Object.freeze({
+  contract_ref: chatTurnRefs.sourceAttribution,
+  kind: "gateway_result_component",
+  shared_object_refs: Object.freeze([runAndSourceRefs.sourceReference]),
+  description:
+    "Normalized source-bearing attribution used for R1 source chips and compact inspection.",
+  required_fields: ["source_ref", "message_segment_id", "attribution_role"],
+  fields: Object.freeze({
+    source_ref: refField,
+    source_region_ref: optionalRefField,
+    message_segment_id: stringField,
+    attribution_role: stringField,
+  }),
+})
+
+export const chatTurnResult = Object.freeze({
+  contract_ref: chatTurnRefs.chatTurnResult,
+  kind: "gateway_result_contract",
+  shared_object_refs: Object.freeze([runAndSourceRefs.sourceReference]),
+  description:
+    "Normalized model-gateway result for a bounded chat turn, carrying output blocks, usage accounting, and source-bearing attribution.",
+  required_fields: ["run_ref", "gateway_execution_ref", "output_blocks", "source_attributions"],
+  fields: Object.freeze({
+    run_ref: refField,
+    gateway_execution_ref: refField,
+    output_blocks: Object.freeze({ type: "array", items: { type: "object" }, min_items: 1 }),
+    source_attributions: Object.freeze({ type: "array", items: { type: "ref" }, default: [] }),
+    finish_reason: stringField,
+    usage_accounting: Object.freeze({ type: "object", allow_additional_fields: true }),
+    provider_session_receipt: optionalRefField,
+  }),
+  invariants: Object.freeze([
+    "Gateway output remains a bounded run result candidate, not durable product truth by itself.",
+  ]),
+})
+
+export const chatTurnFailure = Object.freeze({
+  contract_ref: chatTurnRefs.chatTurnFailure,
+  kind: "gateway_failure_contract",
+  shared_object_refs: Object.freeze([runAndSourceRefs.run]),
+  description:
+    "Typed failure mapping for provider/model execution, including continuity-loss posture that still preserves run identity.",
+  required_fields: ["run_ref", "failure_class", "retryable"],
+  fields: Object.freeze({
+    run_ref: refField,
+    failure_class: stringField,
+    retryable: Object.freeze({ type: "boolean", nullable: false }),
+    provider_session_lost: Object.freeze({ type: "boolean", nullable: false }),
+    normalized_message: stringField,
+    provider_error_code: optionalStringField,
+  }),
+})
+
+export const chatTurnContractCatalog = Object.freeze({
+  package_id: "pkg.model-gateway-contracts.chat-turn",
+  package_version: CHAT_TURN_CONTRACT_VERSION,
+  contracts: Object.freeze({
+    chat_turn_request: chatTurnRequest,
+    source_attribution: sourceAttribution,
+    chat_turn_result: chatTurnResult,
+    chat_turn_failure: chatTurnFailure,
+  }),
+})
+
+export default chatTurnContractCatalog

--- a/docs/control-plane/archive/quarantine-pre-reopen/packages/shared-object-api/run-continuity/index.mjs
+++ b/docs/control-plane/archive/quarantine-pre-reopen/packages/shared-object-api/run-continuity/index.mjs
@@ -1,0 +1,161 @@
+import { runAndSourceRefs } from "../../shared-object-schemas/run-and-source/index.mjs"
+
+const refField = Object.freeze({ type: "ref", nullable: false })
+const optionalRefField = Object.freeze({ type: "ref", nullable: true })
+const stringField = Object.freeze({ type: "string", nullable: false })
+const refArrayField = Object.freeze({ type: "array", items: { type: "ref" }, default: [] })
+
+export const RUN_CONTINUITY_API_VERSION = "1.0.0"
+
+export const runContinuityRefs = Object.freeze({
+  threadContinuityView: "api.run-continuity.thread-view.v1",
+  runInspectionView: "api.run-continuity.run-inspection-view.v1",
+  resumeContinuityView: "api.run-continuity.resume-view.v1",
+  rerunPlanView: "api.run-continuity.rerun-plan.v1",
+})
+
+export const threadContinuityView = Object.freeze({
+  view_ref: runContinuityRefs.threadContinuityView,
+  kind: "shared_object_query_model",
+  shared_object_refs: Object.freeze([
+    runAndSourceRefs.threadLine,
+    runAndSourceRefs.run,
+    runAndSourceRefs.sourceReference,
+  ]),
+  description:
+    "Identity-preserving continuity view for a conversation thread that keeps run history, source history, and provider-loss posture explicit.",
+  required_fields: [
+    "thread_ref",
+    "latest_run_ref",
+    "run_history_refs",
+    "source_ref_ids",
+    "continuity_state",
+    "provider_continuity_required",
+  ],
+  fields: Object.freeze({
+    thread_ref: refField,
+    latest_run_ref: optionalRefField,
+    run_history_refs: refArrayField,
+    source_ref_ids: refArrayField,
+    continuity_state: stringField,
+    provider_continuity_required: Object.freeze({ type: "boolean", const: false }),
+  }),
+  invariants: Object.freeze([
+    "Thread continuity is queryable without treating the thread itself as the consequential truth object.",
+    "Continuity survives model swaps and provider changes through shared refs.",
+  ]),
+})
+
+export const runInspectionView = Object.freeze({
+  view_ref: runContinuityRefs.runInspectionView,
+  kind: "shared_object_query_model",
+  shared_object_refs: Object.freeze([
+    runAndSourceRefs.run,
+    runAndSourceRefs.contextPackSnapshot,
+    runAndSourceRefs.proofBundleSummary,
+    runAndSourceRefs.sourceReference,
+  ]),
+  description:
+    "Compact inspection view that resolves one assistant answer back to the run, admitted-basis snapshot, proof summary, and cited sources behind it.",
+  required_fields: [
+    "run_ref",
+    "context_pack_ref",
+    "proof_bundle_ref",
+    "source_ref_ids",
+    "status",
+  ],
+  fields: Object.freeze({
+    run_ref: refField,
+    context_pack_ref: optionalRefField,
+    proof_bundle_ref: optionalRefField,
+    source_ref_ids: refArrayField,
+    status: stringField,
+    compact_sections: Object.freeze({
+      type: "array",
+      items: { type: "string" },
+      default: ["sources", "admitted_basis", "proof"],
+    }),
+  }),
+  invariants: Object.freeze([
+    "Compact inspection stays anchored to authoritative shared-object refs.",
+    "The view may stay compact, but it may not hide run identity or grounding.",
+  ]),
+})
+
+export const resumeContinuityView = Object.freeze({
+  view_ref: runContinuityRefs.resumeContinuityView,
+  kind: "shared_object_query_model",
+  shared_object_refs: Object.freeze([
+    runAndSourceRefs.threadLine,
+    runAndSourceRefs.run,
+    runAndSourceRefs.contextPackSnapshot,
+  ]),
+  description:
+    "Resume basis for familiar chat continuation without requiring hidden provider transcript continuity.",
+  required_fields: [
+    "thread_ref",
+    "latest_run_ref",
+    "since_last_run_ref",
+    "latest_context_pack_ref",
+    "provider_continuity_required",
+  ],
+  fields: Object.freeze({
+    thread_ref: refField,
+    latest_run_ref: optionalRefField,
+    since_last_run_ref: optionalRefField,
+    latest_context_pack_ref: optionalRefField,
+    provider_continuity_required: Object.freeze({ type: "boolean", const: false }),
+    continuity_notes: Object.freeze({ type: "array", items: { type: "string" }, default: [] }),
+  }),
+  invariants: Object.freeze([
+    "Resume continuity derives from thread, run, and context refs rather than one provider session token.",
+  ]),
+})
+
+export const rerunPlanView = Object.freeze({
+  view_ref: runContinuityRefs.rerunPlanView,
+  kind: "shared_object_query_model",
+  shared_object_refs: Object.freeze([
+    runAndSourceRefs.run,
+    runAndSourceRefs.runInputSnapshot,
+    runAndSourceRefs.contextPackSnapshot,
+  ]),
+  description:
+    "Rerun plan showing how a new run will inherit prior frozen basis links while producing a new run identity.",
+  required_fields: [
+    "prior_run_ref",
+    "input_snapshot_ref",
+    "will_create_new_run_id",
+  ],
+  fields: Object.freeze({
+    prior_run_ref: refField,
+    input_snapshot_ref: refField,
+    prior_context_pack_ref: optionalRefField,
+    will_create_new_run_id: Object.freeze({ type: "boolean", const: true }),
+    carried_source_ref_ids: refArrayField,
+    rerun_reason: stringField,
+  }),
+  invariants: Object.freeze([
+    "Regenerate or rerun behavior always creates a new run rather than mutating prior run truth in place.",
+  ]),
+})
+
+export const runContinuityApiCatalog = Object.freeze({
+  package_id: "pkg.shared-object-api.run-continuity",
+  package_version: RUN_CONTINUITY_API_VERSION,
+  shared_object_dependencies: Object.freeze(Object.values(runAndSourceRefs)),
+  operations: Object.freeze({
+    load_thread_continuity: threadContinuityView.view_ref,
+    load_run_inspection: runInspectionView.view_ref,
+    load_resume_continuity: resumeContinuityView.view_ref,
+    plan_rerun_as_new_run: rerunPlanView.view_ref,
+  }),
+  views: Object.freeze({
+    thread_continuity: threadContinuityView,
+    run_inspection: runInspectionView,
+    resume_continuity: resumeContinuityView,
+    rerun_plan: rerunPlanView,
+  }),
+})
+
+export default runContinuityApiCatalog

--- a/docs/control-plane/archive/quarantine-pre-reopen/packages/shared-object-schemas/run-and-source/index.mjs
+++ b/docs/control-plane/archive/quarantine-pre-reopen/packages/shared-object-schemas/run-and-source/index.mjs
@@ -1,0 +1,274 @@
+const refField = Object.freeze({ type: "ref", nullable: false })
+const optionalRefField = Object.freeze({ type: "ref", nullable: true })
+const stringField = Object.freeze({ type: "string", nullable: false })
+const optionalStringField = Object.freeze({ type: "string", nullable: true })
+const booleanField = Object.freeze({ type: "boolean", nullable: false })
+const refArrayField = Object.freeze({ type: "array", items: { type: "ref" }, default: [] })
+const stringArrayField = Object.freeze({ type: "array", items: { type: "string" }, default: [] })
+
+export const RUN_AND_SOURCE_SCHEMA_VERSION = "1.0.0"
+
+export const runAndSourceRefs = Object.freeze({
+  threadLine: "schema.shared-object.thread-line.v1",
+  runInputSnapshot: "schema.shared-object.run-input-snapshot.v1",
+  run: "schema.shared-object.run.v1",
+  sourceReference: "schema.shared-object.source-reference.v1",
+  contextPackSnapshot: "schema.shared-object.context-pack-snapshot.v1",
+  proofBundleSummary: "schema.shared-object.proof-bundle-summary.v1",
+})
+
+export const threadLineSchema = Object.freeze({
+  schema_ref: runAndSourceRefs.threadLine,
+  object_family: "thread_line",
+  description:
+    "Continuity lane for familiar chat that links runs, artifacts, and branch overlays without becoming the consequential truth anchor.",
+  required_fields: [
+    "thread_id",
+    "scope_ref",
+    "participant_refs",
+    "related_run_refs",
+    "related_branch_refs",
+    "related_artifact_refs",
+    "status",
+    "continuity_metadata",
+  ],
+  fields: Object.freeze({
+    thread_id: stringField,
+    line_id: optionalStringField,
+    scope_ref: refField,
+    participant_refs: Object.freeze({ type: "array", items: { type: "ref" }, min_items: 1 }),
+    related_run_refs: refArrayField,
+    related_branch_refs: refArrayField,
+    related_artifact_refs: refArrayField,
+    status: stringField,
+    continuity_metadata: Object.freeze({
+      type: "object",
+      required_fields: [
+        "latest_run_ref",
+        "latest_resume_basis_ref",
+        "since_last_run_ref",
+        "provider_continuity_required",
+      ],
+      fields: Object.freeze({
+        latest_run_ref: optionalRefField,
+        latest_resume_basis_ref: optionalRefField,
+        since_last_run_ref: optionalRefField,
+        provider_continuity_required: Object.freeze({ ...booleanField, const: false }),
+      }),
+    }),
+  }),
+  invariants: Object.freeze([
+    "Thread continuity may assist familiar chat UX but does not replace run identity.",
+    "Provider-managed conversation state may not be the only continuity mechanism.",
+    "Branch overlays stay linked explicitly rather than being inferred from transcript copies.",
+  ]),
+})
+
+export const runInputSnapshotSchema = Object.freeze({
+  schema_ref: runAndSourceRefs.runInputSnapshot,
+  object_family: "run_input_snapshot",
+  description:
+    "Frozen request-side admission basis captured before execution so replay and audit do not depend on hidden transcript state.",
+  required_fields: [
+    "input_snapshot_ref",
+    "thread_ref",
+    "line_ref",
+    "source_ref_ids",
+    "user_turn_text",
+    "captured_at",
+  ],
+  fields: Object.freeze({
+    input_snapshot_ref: refField,
+    thread_ref: refField,
+    line_ref: optionalRefField,
+    source_ref_ids: refArrayField,
+    attachment_ref_ids: refArrayField,
+    user_turn_text: stringField,
+    objective_summary: optionalStringField,
+    captured_at: stringField,
+  }),
+  invariants: Object.freeze([
+    "The input snapshot is the durable launch basis for a later run.",
+    "Rerun and resume flows keep the snapshot explicit instead of rebuilding it from provider transcript continuity.",
+  ]),
+})
+
+export const runSchema = Object.freeze({
+  schema_ref: runAndSourceRefs.run,
+  object_family: "run",
+  description:
+    "Primary consequential execution unit behind every R1 assistant answer, with stable identity, frozen input basis, and explicit proof and delta links.",
+  required_fields: [
+    "run_id",
+    "run_class",
+    "thread_ref",
+    "objective_spec",
+    "input_snapshot_ref",
+    "status",
+    "proof_bundle_ref",
+    "state_delta_ref",
+  ],
+  fields: Object.freeze({
+    run_id: stringField,
+    run_class: Object.freeze({
+      type: "string",
+      enum: ["synthesize", "extract"],
+    }),
+    thread_ref: refField,
+    objective_spec: Object.freeze({ type: "object", allow_additional_fields: true }),
+    input_snapshot_ref: refField,
+    evidence_pack_ref: optionalRefField,
+    context_pack_ref: optionalRefField,
+    branch_ref: optionalRefField,
+    contract_ref: optionalRefField,
+    authority_scope_ref: optionalRefField,
+    status: Object.freeze({
+      type: "string",
+      enum: ["prepared", "admitted", "executing", "completed", "failed", "cancelled"],
+    }),
+    proof_bundle_ref: refField,
+    state_delta_ref: refField,
+  }),
+  invariants: Object.freeze([
+    "Every consequential assistant answer resolves back to one run.",
+    "Retry, replay, and rerun behavior creates a new run_id instead of mutating prior run truth in place.",
+    "Terminal runs always retain proof and delta links even when the delta is empty.",
+  ]),
+})
+
+export const sourceReferenceSchema = Object.freeze({
+  schema_ref: runAndSourceRefs.sourceReference,
+  object_family: "source_reference",
+  description:
+    "Stable environment-level source identity used for attachments, URLs, and cited source regions across provider changes and reruns.",
+  required_fields: [
+    "source_ref_id",
+    "source_type",
+    "locator",
+    "scope_visibility",
+    "freshness_state",
+    "trust_state",
+    "version_state",
+    "provenance_summary",
+  ],
+  fields: Object.freeze({
+    source_ref_id: stringField,
+    source_type: stringField,
+    locator: Object.freeze({ type: "object", allow_additional_fields: true }),
+    scope_visibility: stringField,
+    freshness_state: stringField,
+    trust_state: stringField,
+    version_state: stringField,
+    provenance_summary: Object.freeze({ type: "object", allow_additional_fields: true }),
+    source_region_refs: refArrayField,
+  }),
+  invariants: Object.freeze([
+    "Source identity stays stable independently of any one thread or provider session.",
+    "Source chips and citations must resolve to this substrate rather than decorative transcript-only references.",
+  ]),
+})
+
+export const contextPackSnapshotSchema = Object.freeze({
+  schema_ref: runAndSourceRefs.contextPackSnapshot,
+  object_family: "context_pack_snapshot",
+  description:
+    "Frozen admitted-basis snapshot for an R1 answer, preserving explicit evidence, memory, canon, and authority inputs behind compact inspection.",
+  required_fields: [
+    "context_pack_id",
+    "input_snapshot_ref",
+    "frozen",
+    "included_source_refs",
+    "memory_lane",
+    "canon_lane",
+    "authority_scope_ref",
+  ],
+  fields: Object.freeze({
+    context_pack_id: stringField,
+    input_snapshot_ref: refField,
+    evidence_pack_ref: optionalRefField,
+    frozen: Object.freeze({ ...booleanField, const: true }),
+    included_source_refs: refArrayField,
+    excluded_source_items: Object.freeze({ type: "array", items: { type: "object" }, default: [] }),
+    memory_lane: Object.freeze({
+      type: "object",
+      required_fields: ["basis_origin", "included_refs", "excluded_items"],
+      fields: Object.freeze({
+        basis_origin: Object.freeze({ type: "string", enum: ["explicit", "fallback", "absent"] }),
+        included_refs: refArrayField,
+        excluded_items: Object.freeze({ type: "array", items: { type: "object" }, default: [] }),
+      }),
+    }),
+    canon_lane: Object.freeze({
+      type: "object",
+      required_fields: ["basis_origin", "mode", "included_refs", "excluded_items"],
+      fields: Object.freeze({
+        basis_origin: Object.freeze({ type: "string", enum: ["explicit", "fallback", "absent"] }),
+        mode: optionalStringField,
+        included_refs: refArrayField,
+        excluded_items: Object.freeze({ type: "array", items: { type: "object" }, default: [] }),
+      }),
+    }),
+    authority_scope_ref: refField,
+    branch_ref: optionalRefField,
+    compaction_notes: stringArrayField,
+  }),
+  invariants: Object.freeze([
+    "Exact replay depends on this snapshot rather than hidden transcript state.",
+    "Explicit-vs-fallback lane origin stays visible for later replay, audit, and R2 inheritance.",
+  ]),
+})
+
+export const proofBundleSummarySchema = Object.freeze({
+  schema_ref: runAndSourceRefs.proofBundleSummary,
+  object_family: "proof_bundle_summary",
+  description:
+    "Compact proof substrate for R1 answers, preserving evidence, omissions, contradictions, and validator outcomes without collapsing into persuasive prose.",
+  required_fields: [
+    "proof_bundle_id",
+    "run_ref",
+    "evidence_refs",
+    "uncertainty_items",
+    "omission_items",
+    "contradiction_items",
+    "summary_sections",
+    "lifecycle_state",
+  ],
+  fields: Object.freeze({
+    proof_bundle_id: stringField,
+    run_ref: refField,
+    evidence_refs: refArrayField,
+    uncertainty_items: Object.freeze({ type: "array", items: { type: "object" }, default: [] }),
+    omission_items: Object.freeze({ type: "array", items: { type: "object" }, default: [] }),
+    contradiction_items: Object.freeze({ type: "array", items: { type: "object" }, default: [] }),
+    validator_result_refs: refArrayField,
+    summary_sections: Object.freeze({ type: "array", items: { type: "string" }, min_items: 1 }),
+    lifecycle_state: Object.freeze({
+      type: "string",
+      enum: ["collected", "reviewed", "accepted", "challenged"],
+    }),
+  }),
+  invariants: Object.freeze([
+    "Compact inspection remains traceable back to the same proof substrate later stages inherit.",
+    "Proof payload stays distinct from UI narration and transcript convenience text.",
+  ]),
+})
+
+export const runAndSourceSchemaCatalog = Object.freeze({
+  package_id: "pkg.shared-object-schemas.run-and-source",
+  package_version: RUN_AND_SOURCE_SCHEMA_VERSION,
+  schema_refs: runAndSourceRefs,
+  objects: Object.freeze({
+    thread_line: threadLineSchema,
+    run_input_snapshot: runInputSnapshotSchema,
+    run: runSchema,
+    source_reference: sourceReferenceSchema,
+    context_pack_snapshot: contextPackSnapshotSchema,
+    proof_bundle_summary: proofBundleSummarySchema,
+  }),
+  notes: Object.freeze([
+    "This package is additive shared-object substrate for the R1 contracts_objects packet.",
+    "Projection-only additions such as Message Block, Conversation Surface, Source Chip, and Resume Packet remain outside this schema-only package.",
+  ]),
+})
+
+export default runAndSourceSchemaCatalog

--- a/docs/control-plane/archive/quarantine-pre-reopen/services/environment-shell-api/conversation-entry/index.mjs
+++ b/docs/control-plane/archive/quarantine-pre-reopen/services/environment-shell-api/conversation-entry/index.mjs
@@ -1,0 +1,87 @@
+import {
+  runContinuityRefs,
+} from "../../../packages/shared-object-api/run-continuity/index.mjs"
+import {
+  runLaunchRefs,
+} from "../../../packages/environment-control-contracts/run-launch/index.mjs"
+
+export const CONVERSATION_ENTRY_SERVICE_VERSION = "1.0.0"
+
+export const conversationEntryRefs = Object.freeze({
+  startConversationEntry: "svc.environment-shell-api.conversation-entry.start.v1",
+  resumeConversationEntry: "svc.environment-shell-api.conversation-entry.resume.v1",
+  rerunConversationEntry: "svc.environment-shell-api.conversation-entry.rerun.v1",
+})
+
+export const startConversationEntry = Object.freeze({
+  entrypoint_ref: conversationEntryRefs.startConversationEntry,
+  kind: "service_entrypoint",
+  accepts_contract_ref: runLaunchRefs.startConversationRunCommand,
+  result_contract_refs: Object.freeze([
+    runLaunchRefs.runLaunchAccepted,
+    runLaunchRefs.runLaunchRejected,
+  ]),
+  continuity_view_ref: runContinuityRefs.threadContinuityView,
+  dispatch_target_ref: "svc.execution-control.run-dispatch.prepare-run.v1",
+  description:
+    "Typed environment-shell entrypoint for starting a bounded R1 conversation run while preserving thread continuity as projection-only state.",
+  invariants: Object.freeze([
+    "Conversation entry may consult continuity views but may not treat the thread as the consequential truth anchor.",
+    "Accepted launches always hand off to execution-control dispatch rather than reaching workers or gateways directly.",
+  ]),
+})
+
+export const resumeConversationEntry = Object.freeze({
+  entrypoint_ref: conversationEntryRefs.resumeConversationEntry,
+  kind: "service_entrypoint",
+  accepts_contract_ref: runLaunchRefs.resumeConversationRunCommand,
+  result_contract_refs: Object.freeze([
+    runLaunchRefs.runLaunchAccepted,
+    runLaunchRefs.runLaunchRejected,
+  ]),
+  continuity_view_ref: runContinuityRefs.resumeContinuityView,
+  dispatch_target_ref: "svc.execution-control.run-dispatch.resume-run.v1",
+  description:
+    "Typed environment-shell entrypoint for continuing a thread from explicit shared refs after provider continuity loss or absence.",
+  invariants: Object.freeze([
+    "Resume continuity remains reconstructable from shared refs even when provider continuity is unavailable.",
+  ]),
+})
+
+export const rerunConversationEntry = Object.freeze({
+  entrypoint_ref: conversationEntryRefs.rerunConversationEntry,
+  kind: "service_entrypoint",
+  accepts_contract_ref: runLaunchRefs.rerunConversationRunCommand,
+  result_contract_refs: Object.freeze([
+    runLaunchRefs.runLaunchAccepted,
+    runLaunchRefs.runLaunchRejected,
+  ]),
+  continuity_view_ref: runContinuityRefs.rerunPlanView,
+  dispatch_target_ref: "svc.execution-control.run-dispatch.rerun-run.v1",
+  description:
+    "Typed environment-shell entrypoint for regenerate-as-new-run behavior that preserves frozen basis links while creating a new run identity.",
+  invariants: Object.freeze([
+    "Rerun remains a new run dispatch and may not overwrite prior run truth.",
+  ]),
+})
+
+export const conversationEntryServiceCatalog = Object.freeze({
+  service_id: "svc.environment-shell-api.conversation-entry",
+  service_version: CONVERSATION_ENTRY_SERVICE_VERSION,
+  workspace_root: "services/environment-shell-api/conversation-entry/",
+  package_dependencies: Object.freeze({
+    continuity_api: runContinuityRefs,
+    run_launch_contracts: runLaunchRefs,
+  }),
+  entrypoints: Object.freeze({
+    start_conversation: startConversationEntry,
+    resume_conversation: resumeConversationEntry,
+    rerun_conversation: rerunConversationEntry,
+  }),
+  notes: Object.freeze([
+    "This module materializes the R1 runtime_execution environment-shell entrypoint seam only.",
+    "App routes remain out of scope for this packet and continue later under surface_validation.",
+  ]),
+})
+
+export default conversationEntryServiceCatalog

--- a/docs/control-plane/archive/quarantine-pre-reopen/services/event-provenance/run-trace/index.mjs
+++ b/docs/control-plane/archive/quarantine-pre-reopen/services/event-provenance/run-trace/index.mjs
@@ -1,0 +1,76 @@
+import {
+  runLineageRefs,
+} from "../../../packages/event-provenance-contracts/run-lineage/index.mjs"
+
+export const RUN_TRACE_SERVICE_VERSION = "1.0.0"
+
+export const runTraceRefs = Object.freeze({
+  publishRunLifecycle: "svc.event-provenance.run-trace.publish-run-lifecycle.v1",
+  publishSourceResolution: "svc.event-provenance.run-trace.publish-source-resolution.v1",
+  publishResumeContinuity: "svc.event-provenance.run-trace.publish-resume-continuity.v1",
+  queryRunTrace: "svc.event-provenance.run-trace.query.v1",
+})
+
+export const publishRunLifecycle = Object.freeze({
+  entrypoint_ref: runTraceRefs.publishRunLifecycle,
+  kind: "provenance_route",
+  accepts_contract_ref: runLineageRefs.runLifecycleEvent,
+  description:
+    "Append-only provenance route for prepared, admitted, executing, and terminal R1 run lifecycle events.",
+  invariants: Object.freeze([
+    "Lifecycle facts stay append-only and reconstructable after provider continuity loss.",
+  ]),
+})
+
+export const publishSourceResolution = Object.freeze({
+  entrypoint_ref: runTraceRefs.publishSourceResolution,
+  kind: "provenance_route",
+  accepts_contract_ref: runLineageRefs.sourceResolutionEvent,
+  description:
+    "Append-only provenance route for source attachment, inclusion, exclusion, and citation facts used by compact R1 inspection.",
+  invariants: Object.freeze([
+    "Source chips and compact inspection derive from stable source lineage rather than transcript-local guesses.",
+  ]),
+})
+
+export const publishResumeContinuity = Object.freeze({
+  entrypoint_ref: runTraceRefs.publishResumeContinuity,
+  kind: "provenance_route",
+  accepts_contract_ref: runLineageRefs.resumeContinuityEvent,
+  description:
+    "Append-only provenance route for resume-basis creation and provider-continuity-loss handling.",
+  invariants: Object.freeze([
+    "Resume continuity remains explicit and queryable even when provider continuity is absent.",
+  ]),
+})
+
+export const queryRunTrace = Object.freeze({
+  entrypoint_ref: runTraceRefs.queryRunTrace,
+  kind: "provenance_query_route",
+  accepts_contract_ref: runLineageRefs.runLineageQuery,
+  description:
+    "Typed lineage query route over run lifecycle, source-resolution, and resume-continuity events for R1 continuity reads.",
+  invariants: Object.freeze([
+    "Queries reconstruct trace state from append-only events instead of ambient chat history.",
+  ]),
+})
+
+export const runTraceServiceCatalog = Object.freeze({
+  service_id: "svc.event-provenance.run-trace",
+  service_version: RUN_TRACE_SERVICE_VERSION,
+  workspace_root: "services/event-provenance/run-trace/",
+  package_dependencies: Object.freeze({
+    run_lineage_contracts: runLineageRefs,
+  }),
+  routes: Object.freeze({
+    publish_run_lifecycle: publishRunLifecycle,
+    publish_source_resolution: publishSourceResolution,
+    publish_resume_continuity: publishResumeContinuity,
+    query_run_trace: queryRunTrace,
+  }),
+  notes: Object.freeze([
+    "This service materializes the append-only R1 run-trace seam and does not introduce alternate truth stores.",
+  ]),
+})
+
+export default runTraceServiceCatalog

--- a/docs/control-plane/archive/quarantine-pre-reopen/services/execution-control/run-dispatch/index.mjs
+++ b/docs/control-plane/archive/quarantine-pre-reopen/services/execution-control/run-dispatch/index.mjs
@@ -1,0 +1,122 @@
+import {
+  runLaunchRefs,
+} from "../../../packages/environment-control-contracts/run-launch/index.mjs"
+import {
+  admittedBasisRefs,
+} from "../../../packages/context-compiler-contracts/admitted-basis/index.mjs"
+import {
+  chatTurnRefs,
+} from "../../../packages/model-gateway-contracts/chat-turn/index.mjs"
+import {
+  runLineageRefs,
+} from "../../../packages/event-provenance-contracts/run-lineage/index.mjs"
+
+export const RUN_DISPATCH_SERVICE_VERSION = "1.0.0"
+
+export const runDispatchRefs = Object.freeze({
+  prepareRun: "svc.execution-control.run-dispatch.prepare-run.v1",
+  resumeRun: "svc.execution-control.run-dispatch.resume-run.v1",
+  rerunRun: "svc.execution-control.run-dispatch.rerun-run.v1",
+  admitCompiledRun: "svc.execution-control.run-dispatch.admit-compiled-run.v1",
+  completeGatewayRun: "svc.execution-control.run-dispatch.complete-gateway-run.v1",
+})
+
+export const prepareRunDispatch = Object.freeze({
+  dispatch_ref: runDispatchRefs.prepareRun,
+  kind: "dispatch_route",
+  accepts_contract_ref: runLaunchRefs.runLaunchAccepted,
+  emits_job_ref: admittedBasisRefs.compileRunContextCommand,
+  publishes_lineage_ref: runLineageRefs.runLifecycleEvent,
+  next_worker_ref: "worker.context-compiler.compile-run-context.execute.v1",
+  description:
+    "Dispatch route for a newly prepared R1 run that freezes the admitted basis before any model execution starts.",
+  invariants: Object.freeze([
+    "Prepared runs must compile the admitted basis before gateway execution.",
+    "Lifecycle publication stays append-only and run-scoped.",
+  ]),
+})
+
+export const resumeRunDispatch = Object.freeze({
+  dispatch_ref: runDispatchRefs.resumeRun,
+  kind: "dispatch_route",
+  accepts_contract_ref: runLaunchRefs.runLaunchAccepted,
+  emits_job_ref: admittedBasisRefs.compileRunContextCommand,
+  publishes_lineage_ref: runLineageRefs.resumeContinuityEvent,
+  next_worker_ref: "worker.context-compiler.compile-run-context.execute.v1",
+  description:
+    "Dispatch route for explicit-resume launches that keeps provider-loss posture visible while reusing the same admitted-basis compiler seam.",
+  invariants: Object.freeze([
+    "Resume dispatch preserves explicit continuity events rather than hiding them in provider-local state.",
+  ]),
+})
+
+export const rerunRunDispatch = Object.freeze({
+  dispatch_ref: runDispatchRefs.rerunRun,
+  kind: "dispatch_route",
+  accepts_contract_ref: runLaunchRefs.runLaunchAccepted,
+  emits_job_ref: admittedBasisRefs.compileRunContextCommand,
+  publishes_lineage_ref: runLineageRefs.runLifecycleEvent,
+  next_worker_ref: "worker.context-compiler.compile-run-context.execute.v1",
+  description:
+    "Dispatch route for regenerate-as-new-run behavior that preserves rerun lineage while still recompiling a fresh admitted basis.",
+  invariants: Object.freeze([
+    "Rerun dispatch never reuses a prior run identity.",
+  ]),
+})
+
+export const admitCompiledRunDispatch = Object.freeze({
+  dispatch_ref: runDispatchRefs.admitCompiledRun,
+  kind: "dispatch_route",
+  accepts_contract_ref: admittedBasisRefs.compileRunContextResult,
+  emits_gateway_ref: chatTurnRefs.chatTurnRequest,
+  publishes_lineage_ref: runLineageRefs.runLifecycleEvent,
+  next_service_ref: "svc.model-gateway.chat-turn-execution.execute.v1",
+  description:
+    "Dispatch route that turns a frozen admitted basis into one bounded provider-facing chat-turn request.",
+  invariants: Object.freeze([
+    "Gateway execution starts only after the admitted basis is frozen.",
+  ]),
+})
+
+export const completeGatewayRunDispatch = Object.freeze({
+  dispatch_ref: runDispatchRefs.completeGatewayRun,
+  kind: "dispatch_route",
+  accepts_contract_refs: Object.freeze([
+    chatTurnRefs.chatTurnResult,
+    chatTurnRefs.chatTurnFailure,
+  ]),
+  publishes_lineage_refs: Object.freeze([
+    runLineageRefs.runLifecycleEvent,
+    runLineageRefs.sourceResolutionEvent,
+  ]),
+  trace_service_ref: "svc.event-provenance.run-trace.publish-run-lifecycle.v1",
+  description:
+    "Dispatch route that closes the bounded R1 run by publishing lifecycle and source-resolution trace facts from the normalized gateway outcome.",
+  invariants: Object.freeze([
+    "Completion remains reconstructable from append-only run and source events.",
+  ]),
+})
+
+export const runDispatchServiceCatalog = Object.freeze({
+  service_id: "svc.execution-control.run-dispatch",
+  service_version: RUN_DISPATCH_SERVICE_VERSION,
+  workspace_root: "services/execution-control/run-dispatch/",
+  package_dependencies: Object.freeze({
+    run_launch_contracts: runLaunchRefs,
+    admitted_basis_contracts: admittedBasisRefs,
+    chat_turn_contracts: chatTurnRefs,
+    run_lineage_contracts: runLineageRefs,
+  }),
+  dispatch_routes: Object.freeze({
+    prepare_run: prepareRunDispatch,
+    resume_run: resumeRunDispatch,
+    rerun_run: rerunRunDispatch,
+    admit_compiled_run: admitCompiledRunDispatch,
+    complete_gateway_run: completeGatewayRunDispatch,
+  }),
+  notes: Object.freeze([
+    "This service stays inside execution-control orchestration and does not own provider logic, app projections, or shared-object authorship.",
+  ]),
+})
+
+export default runDispatchServiceCatalog

--- a/docs/control-plane/archive/quarantine-pre-reopen/services/model-gateway/chat-turn-execution/index.mjs
+++ b/docs/control-plane/archive/quarantine-pre-reopen/services/model-gateway/chat-turn-execution/index.mjs
@@ -1,0 +1,55 @@
+import {
+  chatTurnRefs,
+} from "../../../packages/model-gateway-contracts/chat-turn/index.mjs"
+
+export const CHAT_TURN_EXECUTION_SERVICE_VERSION = "1.0.0"
+
+export const chatTurnExecutionRefs = Object.freeze({
+  executeChatTurn: "svc.model-gateway.chat-turn-execution.execute.v1",
+  normalizeChatTurnFailure: "svc.model-gateway.chat-turn-execution.normalize-failure.v1",
+})
+
+export const executeChatTurn = Object.freeze({
+  entrypoint_ref: chatTurnExecutionRefs.executeChatTurn,
+  kind: "gateway_execution_route",
+  accepts_contract_ref: chatTurnRefs.chatTurnRequest,
+  success_contract_ref: chatTurnRefs.chatTurnResult,
+  failure_contract_ref: chatTurnRefs.chatTurnFailure,
+  description:
+    "Typed model-gateway execution route for one bounded R1 assistant answer over a frozen admitted basis.",
+  invariants: Object.freeze([
+    "Gateway execution consumes frozen admitted-basis inputs and may not rebuild truth from transcript continuity.",
+    "Provider session hints remain optional UX aids and do not become durable run truth.",
+  ]),
+})
+
+export const normalizeChatTurnFailure = Object.freeze({
+  entrypoint_ref: chatTurnExecutionRefs.normalizeChatTurnFailure,
+  kind: "gateway_failure_route",
+  accepts_contract_ref: chatTurnRefs.chatTurnFailure,
+  emits_contract_ref: chatTurnRefs.chatTurnFailure,
+  description:
+    "Normalization route for provider/model failures that preserves run identity and provider-continuity-loss posture as typed gateway output.",
+  invariants: Object.freeze([
+    "Failure normalization does not erase the run or collapse provider loss into generic transcript noise.",
+  ]),
+})
+
+export const chatTurnExecutionServiceCatalog = Object.freeze({
+  service_id: "svc.model-gateway.chat-turn-execution",
+  service_version: CHAT_TURN_EXECUTION_SERVICE_VERSION,
+  workspace_root: "services/model-gateway/chat-turn-execution/",
+  package_dependencies: Object.freeze({
+    chat_turn_contracts: chatTurnRefs,
+  }),
+  routes: Object.freeze({
+    execute_chat_turn: executeChatTurn,
+    normalize_chat_turn_failure: normalizeChatTurnFailure,
+  }),
+  notes: Object.freeze([
+    "This gateway module stays inside typed provider execution and normalization only.",
+    "Shared-object authorship, review semantics, and app projection logic remain outside this service boundary.",
+  ]),
+})
+
+export default chatTurnExecutionServiceCatalog

--- a/docs/control-plane/archive/quarantine-pre-reopen/workers/context-compiler/compile-run-context/index.mjs
+++ b/docs/control-plane/archive/quarantine-pre-reopen/workers/context-compiler/compile-run-context/index.mjs
@@ -1,0 +1,64 @@
+import {
+  runContinuityRefs,
+} from "../../../packages/shared-object-api/run-continuity/index.mjs"
+import {
+  admittedBasisRefs,
+} from "../../../packages/context-compiler-contracts/admitted-basis/index.mjs"
+
+export const COMPILE_RUN_CONTEXT_WORKER_VERSION = "1.0.0"
+
+export const compileRunContextWorkerRefs = Object.freeze({
+  executeCompileRunContext: "worker.context-compiler.compile-run-context.execute.v1",
+  publishCompiledBasis: "worker.context-compiler.compile-run-context.publish-basis.v1",
+})
+
+export const executeCompileRunContext = Object.freeze({
+  worker_ref: compileRunContextWorkerRefs.executeCompileRunContext,
+  kind: "worker_job_route",
+  accepts_contract_ref: admittedBasisRefs.compileRunContextCommand,
+  record_contract_ref: admittedBasisRefs.admittedBasisRecord,
+  result_contract_ref: admittedBasisRefs.compileRunContextResult,
+  inspection_view_refs: Object.freeze([
+    runContinuityRefs.runInspectionView,
+    runContinuityRefs.resumeContinuityView,
+  ]),
+  description:
+    "Bounded context-compiler worker that freezes the admitted basis for one R1 run before provider invocation.",
+  invariants: Object.freeze([
+    "Explicit admitted inputs take precedence over fallback lane selection.",
+    "Provider session hints remain advisory only and never become the replay basis.",
+    "The worker emits a frozen admitted-basis record and compact inspection-ready result for the same run.",
+  ]),
+})
+
+export const publishCompiledBasis = Object.freeze({
+  worker_ref: compileRunContextWorkerRefs.publishCompiledBasis,
+  kind: "worker_result_route",
+  accepts_contract_ref: admittedBasisRefs.compileRunContextResult,
+  next_dispatch_ref: "svc.execution-control.run-dispatch.admit-compiled-run.v1",
+  description:
+    "Worker result route that hands the frozen admitted-basis result back to execution-control for bounded chat-turn execution.",
+  invariants: Object.freeze([
+    "Context compilation remains a worker seam over frozen refs and returns control through typed dispatch rather than app-local shortcuts.",
+  ]),
+})
+
+export const compileRunContextWorkerCatalog = Object.freeze({
+  worker_id: "worker.context-compiler.compile-run-context",
+  worker_version: COMPILE_RUN_CONTEXT_WORKER_VERSION,
+  workspace_root: "workers/context-compiler/compile-run-context/",
+  package_dependencies: Object.freeze({
+    continuity_api: runContinuityRefs,
+    admitted_basis_contracts: admittedBasisRefs,
+  }),
+  jobs: Object.freeze({
+    execute_compile_run_context: executeCompileRunContext,
+    publish_compiled_basis: publishCompiledBasis,
+  }),
+  notes: Object.freeze([
+    "This worker materializes the R1 admitted-basis compiler seam only.",
+    "Pack editing, replay/compare, and later-stage context controls remain outside this packet.",
+  ]),
+})
+
+export default compileRunContextWorkerCatalog


### PR DESCRIPTION
Per DEC-RO-05 archive-then-delete option selected 2026-04-24.

### What this commits
11 .mjs files (1,369 LOC) + README.md under `docs/control-plane/archive/quarantine-pre-reopen/`.

### Why (factual correction to DEC-RO-05)
The decision record assumed these files were in Canon's git history and would be `git rm -r`'d by the deletion packet. Verification after recording the decision revealed the files were UNCOMMITTED local workspace state only. The remote Canon repo had no trace of them. Archive-then-delete is the path that preserves design knowledge through git history.

### Next steps
1. Merge this PR (files preserved in git history under clearly-archival path)
2. Update packet `pkt.quarantine-invariant-sweep.v1` scaffold to read from `docs/control-plane/archive/quarantine-pre-reopen/` instead of the (never-existed-in-git) `Canon/packages/` path
3. Re-trigger invariant-sweep issue — it will now find the files and port invariants to spec-digests
4. `pkt.quarantine-delete.v1` is NO LONGER needed (there is nothing to delete from git); it will be superseded by a simpler `pkt.finalize-quarantine-disposition.v1` packet that just updates phase-6 prose + canon-now.md
5. Plan-owner deletes local workspace directories manually

This archive path is permanent. The files are preserved in git forever; future readers encountering a reference to `Canon/packages/` in old docs can retrieve the content from this path.