### PR TITLE
feat(packets): Update sweep path + add authority-prose reconciliation packet

### DIFF
--- a/docs/control-plane/implementation/packets/remediation/pkt.quarantine-invariant-sweep.v1.md
+++ b/docs/control-plane/implementation/packets/remediation/pkt.quarantine-invariant-sweep.v1.md
@@ -11,27 +11,29 @@
 
 Before any physical removal of the quarantined draft directories (`Canon/packages/`, `Canon/services/`, `Canon/workers/`), extract every design invariant encoded in their `.mjs` contract-as-code files, identify which invariants are already captured in the post-reopen spec-digests, and port any uncaptured invariants as one-liners into the correct spec-digest file. This preserves design knowledge that git history alone doesn't make discoverable.
 
-## Factual basis (pre-audited during decision)
+## Factual basis (pre-audited during decision, corrected 2026-04-24)
 
-- **Files in scope**: 11 `.mjs` files totaling 1,369 LOC across 3 directories:
-  - `Canon/packages/context-compiler-contracts/admitted-basis/index.mjs`
-  - `Canon/packages/environment-control-contracts/run-launch/index.mjs`
-  - `Canon/packages/event-provenance-contracts/run-lineage/index.mjs`
-  - `Canon/packages/model-gateway-contracts/chat-turn/index.mjs`
-  - `Canon/packages/shared-object-api/run-continuity/index.mjs`
-  - `Canon/packages/shared-object-schemas/run-and-source/index.mjs`
-  - `Canon/services/environment-shell-api/conversation-entry/index.mjs`
-  - `Canon/services/event-provenance/run-trace/index.mjs`
-  - `Canon/services/execution-control/run-dispatch/index.mjs`
-  - `Canon/services/model-gateway/chat-turn-execution/index.mjs`
-  - `Canon/workers/context-compiler/compile-run-context/index.mjs`
-- **Inbound imports**: zero from outside `Canon/` (audited).
-- **Ref-name overlap with control-plane**: zero (audited).
+**IMPORTANT CORRECTION**: The decision record originally expected these files under `Canon/packages/`, `Canon/services/`, `Canon/workers/`. Post-decision verification revealed those files were UNCOMMITTED local workspace state that never reached remote git. They were preserved via a one-time archival commit (Canon PR #25, merged 2026-04-24) under `docs/control-plane/archive/quarantine-pre-reopen/`. This packet now reads from that archive path.
+
+- **Files in scope**: 11 `.mjs` files totaling 1,369 LOC under `docs/control-plane/archive/quarantine-pre-reopen/`:
+  - `packages/context-compiler-contracts/admitted-basis/index.mjs`
+  - `packages/environment-control-contracts/run-launch/index.mjs`
+  - `packages/event-provenance-contracts/run-lineage/index.mjs`
+  - `packages/model-gateway-contracts/chat-turn/index.mjs`
+  - `packages/shared-object-api/run-continuity/index.mjs`
+  - `packages/shared-object-schemas/run-and-source/index.mjs`
+  - `services/environment-shell-api/conversation-entry/index.mjs`
+  - `services/event-provenance/run-trace/index.mjs`
+  - `services/execution-control/run-dispatch/index.mjs`
+  - `services/model-gateway/chat-turn-execution/index.mjs`
+  - `workers/context-compiler/compile-run-context/index.mjs`
+- **Inbound imports into the live Canon or satellite repos**: zero (audited; confirmed none reference the archive path either).
+- **Ref-name overlap with control-plane artifact-registry**: zero (audited).
 - **Domain overlap with spec-digests**: present but under different naming.
 
 ## Execution steps
 
-1. **Extract**: For each of the 11 `.mjs` files, parse out every `invariants: Object.freeze([...])` array. Record each invariant as: `{file, contract_catalog_id, invariant_text}`.
+1. **Extract**: For each of the 11 `.mjs` files under `docs/control-plane/archive/quarantine-pre-reopen/`, parse out every `invariants: Object.freeze([...])` array. Record each invariant as: `{file, contract_catalog_id, invariant_text}`.
 
 2. **Map to spec digest**: For each extracted invariant, identify the target spec digest under `docs/spec-digests/` by subject:
    - `context-compiler-*` → `docs/spec-digests/agentic-engine/engine-compiler.md`
@@ -58,21 +60,21 @@ Before any physical removal of the quarantined draft directories (`Canon/package
    - ...
    ```
 
-5. **Do NOT delete the .mjs files**. This packet is read-and-append only.
+5. **Do NOT delete the .mjs files** from `docs/control-plane/archive/quarantine-pre-reopen/`. This packet is read-and-append only. The archive is permanent.
 
 ## Forbidden
 
-- Do NOT delete, rename, or modify any file under `Canon/packages/`, `Canon/services/`, `Canon/workers/`. That is Packet B's job.
+- Do NOT delete, rename, or modify any file under `docs/control-plane/archive/quarantine-pre-reopen/`. The archive is permanent.
 - Do NOT touch `canon-now.md`, `canon-knowledgebase/`, `AGENTIC_ENGINE_AUDIT_LOG.md`, `CANON_PLAN_IMPACT_REPORT.md` (authority records).
-- Do NOT invent invariants. Only port invariants that exist verbatim in the `.mjs` source.
+- Do NOT invent invariants. Only port invariants that exist verbatim in the archive source.
 - Do NOT merge invariants from different source files into one bullet. One invariant = one bullet, with origin attribution.
 
 ## Verification
 
 - `git diff --stat` shows changes ONLY in `docs/spec-digests/*.md` files.
-- `git diff -- Canon/packages Canon/services Canon/workers` is empty.
+- `git diff -- docs/control-plane/archive/quarantine-pre-reopen` is empty (archive is read-only).
 - PR body lists every invariant found (categorized as "ported" vs "already-captured, skipped") with file attribution.
-- A final checklist confirms all 11 source files were scanned.
+- A final checklist confirms all 11 source files under the archive were scanned.
 - `pnpm typecheck` (if applicable in Canon) + Canon's spec-digest validation remain green.
 
 ## PR body template

--- a/docs/control-plane/implementation/packets/remediation/pkt.reconcile-authority-prose-post-dec-ro-04.v1.md
+++ b/docs/control-plane/implementation/packets/remediation/pkt.reconcile-authority-prose-post-dec-ro-04.v1.md
@@ -1,0 +1,56 @@
+# pkt.reconcile-authority-prose-post-dec-ro-04.v1
+
+- **Packet ID**: `pkt.reconcile-authority-prose-post-dec-ro-04.v1`
+- **Authority**: DEC-RO-04 recorded at `canon-knowledgebase/post-reopen-decisions/condition-e-license.md`
+- **Carry-forward**: CF-0095 (extends)
+- **Scope**: `SaintFreddy/Canon` workspace-level authority files (AGENTIC_WORKFLOW.md + CANON_PLAN_IMPACT_REPORT.md)
+- **Ordering**: After `pkt.add-proprietary-license.v1` (Canon side) has merged. The LICENSE file must exist before prose that references "our LICENSE" makes sense.
+- **Execution mode**: **Semi-autonomous** — droid drafts the exact edits, opens a PR, but flags this as a special-case authority edit in the PR body so a human can confirm before auto-merge.
+
+## Why this is a separate packet
+
+The LICENSE packet's executing droid was appropriately conservative and did NOT touch `AGENTIC_WORKFLOW.md` or `CANON_PLAN_IMPACT_REPORT.md` because those are marked read-only in `canon-now.md`. DEC-RO-04's decision record explicitly authorizes two narrow edits to those files, but "explicit decision-record authorization" is rare enough that it warrants its own packet rather than being rolled into the broader LICENSE packet.
+
+## Goal
+
+Execute the two narrow, decision-authorized edits to authority-adjacent prose so documented posture matches DEC-RO-04 reality:
+
+1. **AGENTIC_WORKFLOW.md §9 L426** — the "public SDK posture" phrasing. Two variants; executor picks based on context and documents choice in PR body:
+   - **Variant A (preferred)**: Mark the phrase as aspirational / not current. Example patch:
+     > Before: `Canon aims for public SDK posture with community-friendly tooling.`
+     > After: `Canon aims for public SDK posture with community-friendly tooling *[aspirational only; not current license posture. DEC-RO-04 (2026-04-24) set current LICENSE to Proprietary / All Rights Reserved; see `canon-knowledgebase/post-reopen-decisions/condition-e-license.md` for revisit conditions.]*`
+   - **Variant B (fallback)**: Remove the phrasing entirely if Variant A breaks §9's flow.
+
+2. **CANON_PLAN_IMPACT_REPORT.md §6 row 6** — append a single new row (not modify existing rows) in the §6 decision ledger noting DEC-RO-04 landed on Option 4. Exact append format:
+   > `| e.2 | LICENSE choice | 2026-04-24 | SaintFreddy | Option 4 — Proprietary / All Rights Reserved | DEC-RO-04 | See canon-knowledgebase/post-reopen-decisions/condition-e-license.md |`
+   Adjust column format to match the existing table header in §6.
+
+## File whitelist
+
+- `AGENTIC_WORKFLOW.md` (modify §9 only; do NOT touch other sections)
+- `CANON_PLAN_IMPACT_REPORT.md` (append one row to §6 only; do NOT modify existing rows or sections)
+
+Do NOT modify:
+- `canon-now.md`
+- `AGENTIC_ENGINE_AUDIT_LOG.md`
+- Any other file — these 2 edits are narrow exceptions; everything else is out of scope.
+
+## Forbidden
+
+- Do NOT rewrite or rephrase any existing prose in §9 or §6 beyond the specific markup addition / row append described above.
+- Do NOT treat this packet as authorization to make other authority-record edits. Each such edit requires its own decision record + its own packet.
+- Do NOT touch §1-§8 or §10+ of AGENTIC_WORKFLOW.md. Only §9 L426 area is authorized.
+
+## Verification
+
+- `git diff AGENTIC_WORKFLOW.md` shows ONE additive change in the §9 area (aspirational markup) OR one small deletion (Variant B).
+- `git diff CANON_PLAN_IMPACT_REPORT.md` shows exactly ONE new row appended to §6, no other changes.
+- PR body quotes the exact before/after for each change so reviewer can verify the narrow scope.
+
+## PR labelling
+
+PR title must start with: `chore(authority-edit):` — this signals to human reviewers that this is an authorized exception to the usual read-only rule.
+
+## Human-merge preference
+
+Despite auto-merge being enabled elsewhere, this PR should NOT auto-merge by admin squash unless a human approves, because the edits touch authority-adjacent files. The PR body should explicitly note: "Human review preferred before merge."


### PR DESCRIPTION
Two packet updates after the post-decision factual correction:

1. **pkt.quarantine-invariant-sweep.v1** now reads from `docs/control-plane/archive/quarantine-pre-reopen/` (the new archive path from PR #25) instead of the never-in-git `Canon/packages/` path.
2. **pkt.reconcile-authority-prose-post-dec-ro-04.v1** (new) handles the narrow AGENTIC_WORKFLOW.md §9 + CANON_PLAN_IMPACT_REPORT.md §6 edits that the LICENSE packet conservatively declined to make. Marked `chore(authority-edit):` in PR title; human-review preferred before merge despite autonomy defaults.