### PR TITLE
chore(kb): Demote Stage Plan from canon-phase-4-plus-plan.md to new sibling

### DIFF
--- a/canon-knowledgebase/canon-phase-4-plus-plan-stage-plan.md
+++ b/canon-knowledgebase/canon-phase-4-plus-plan-stage-plan.md
@@ -1,0 +1,249 @@
+# Canon Phase 4+ Plan — Stage Plan
+
+## Purpose
+
+This file preserves the full release-stage authority (Platform Gate + `R1`..`R7`) that was originally inline inside `canon-ref:dev/kb/canon-phase-4-plus-plan`.
+
+The active plan file keeps only a compact pointer to this file on its hot recovery surface. Open this file only when a plan-owner-selected release stage becomes the active bounded step.
+
+This file is forward-looking authority, not historical scaffolding. It defines what each release stage must honestly demonstrate for the knowledgebase architecture to inherit correctly. It is declared in the active plan's `preserves_as_stage_authority` list.
+
+## Scope
+
+One subsection per stage, in release order:
+
+- Platform Gate
+- `R1` Transcript Chat
+- `R2` Context Chat
+- `R3` Branch / Visual Thinker
+- `R4` Artifact Workspace
+- `R5` Prompt Studio
+- `R6` Governed Agent / Applet Chat
+- `R7` Commissioning Bridge
+
+Every stage uses the same four-field shape:
+
+- **Architecture or user promise** — what the release honestly communicates
+- **Knowledgebase obligations at this stage** — what the substrate must support
+- **Package-maturity posture that matters most here** — which maturity levels must be real
+- **Intentional deferrals and refusals** — what this stage specifically does not claim
+- **Exit signal** — the test that the stage has done enough
+
+## Cross-Stage Guardrails reference
+
+The authoritative `Cross-Stage Guardrails` block remains in `canon-ref:dev/kb/canon-phase-4-plus-plan` because it applies across every stage below. Read both files together whenever a stage section is active.
+
+## Stage Plan
+
+### Platform Gate
+
+Architecture goal: prove the substrate is real enough that every public release can inherit knowledge participation without pretending transcript continuity is truth.
+
+Knowledgebase obligations at this stage:
+
+- memory and canon injection are real engine seams with authoritative refs and frozen replay basis behavior
+- append-only knowledge observation, proposal, decision, and state-transition events are real shared-environment substrate
+- proposal, review, approval, and apply paths for memory and canon are executable on real paths, even if still internal-facing
+- passive capture starts as scoped observation intake and proposal substrate, not as user-facing autonomous memory magic
+- operator and audit surfaces can show what knowledge participated in a run and why it was admitted or blocked
+
+Package-maturity posture that matters most here:
+
+- all package areas must already be real at `M1`
+- `pkg.context-compiler`, `pkg.shared-object-api`, `pkg.event-provenance-spine`, and `pkg.review-writeback` must be real enough that later stages inherit them instead of debating their existence
+
+Intentional deferrals and refusals:
+
+- no public learning product promise yet
+- no transcript-private memory behavior
+- no branch, artifact, prompt, applet, or commissioning semantics smuggled in early
+- no silent background promotion of candidate learning
+
+Exit signal:
+
+`R1` can honestly expose bounded runs with explicit knowledge participation because the substrate beneath that story is already real.
+
+### R1 Transcript Chat
+
+User promise: this still feels familiar, but each answer is a bounded run with explicit grounding rather than transcript-owned truth.
+
+Knowledgebase obligations at this stage:
+
+- disclose when memory or canon participated in a run
+- preserve compact visibility into included and excluded knowledge basis records
+- keep candidate learning internal or visibly marked as suggestion-only rather than injecting it by default
+- keep early reviewer and operator surfaces honest even if full governance UX is not yet public-facing
+
+Package-maturity posture that matters most here:
+
+- `pkg.environment-control` -> `M3`
+- `pkg.context-compiler` -> `M3`
+- `pkg.shared-object-api`, `pkg.model-gateway`, `pkg.event-provenance-spine`, and `pkg.monitor-inspect` -> `M2`
+
+Intentional deferrals and refusals:
+
+- not full context editing
+- not artifact-centered continuity
+- not hidden memory accumulation
+- not governed reusable execution
+
+Exit signal:
+
+Users can see that knowledge participation is real and explicit, while the product still avoids pretending that `R1` offers full memory governance.
+
+### R2 Context Chat
+
+User promise: context control becomes explicit and replayable instead of being tucked behind invisible defaults.
+
+Knowledgebase obligations at this stage:
+
+- include, exclude, pin, and challenge controls operate over active memory and canon participation
+- the system can show why a memory or canon record was included, excluded, blocked, previewed, or constrained
+- user corrections can open proposal-bearing flows without collapsing directly into accepted truth
+- passive capture and early distillation stay proposal-first and visibly scoped
+
+Package-maturity posture that matters most here:
+
+- `pkg.context-compiler` -> `M4`
+- `pkg.shared-object-api` -> `M3`
+- `pkg.event-provenance-spine` -> `M3`
+- `pkg.monitor-inspect` -> `M3`
+- `pkg.replay-compare` -> `M2`
+
+Intentional deferrals and refusals:
+
+- not branch-map semantics yet
+- not artifact-governance center of gravity yet
+- not fake context control that only edits sidebars while hidden defaults continue elsewhere
+
+Exit signal:
+
+`R2` can expose real pack control over knowledge participation without widening into fake branching or early artifact governance.
+
+### R3 Branch / Visual Thinker
+
+User promise: branches, replay, compare, and mode projections can vary assumptions without breaking run truth.
+
+Knowledgebase obligations at this stage:
+
+- exact replay reuses frozen knowledge refs from the original basis
+- altered replay and compare report explicit knowledge-basis diffs instead of silently rerunning mutable discovery
+- suspensions, supersessions, and branch-local differences stay queryable and explainable
+- merge and conflict surfaces treat knowledge disagreements as governed state, not transcript drift
+
+Package-maturity posture that matters most here:
+
+- `pkg.event-provenance-spine` -> `M4`
+- `pkg.replay-compare` -> `M4`
+- `pkg.review-writeback` -> `M2`
+
+Intentional deferrals and refusals:
+
+- not artifact review center yet
+- not prompt or applet infrastructure milestone
+- not transcript cloning presented as branching
+
+Exit signal:
+
+Canon can distinguish same-basis replay from changed-basis replay without hand-waving over knowledge lineage.
+
+### R4 Artifact Workspace
+
+User promise: continuity shifts from transcript gravity to artifacts, proposals, reviews, approvals, and durable run-linked work.
+
+Knowledgebase obligations at this stage:
+
+- artifact-linked knowledge proposals become the main durable promotion path
+- objections, alternatives, suspensions, and supersessions stay first-class shared-environment governance records
+- accepted memory and canon remain tied back to run, proof, delta, artifact, and approval lineage
+- artifact-centered continuity inherits the same knowledgebase rather than inventing a new truth model
+
+Package-maturity posture that matters most here:
+
+- `pkg.shared-object-api` -> `M4`
+- `pkg.review-writeback` -> `M4`
+
+Intentional deferrals and refusals:
+
+- not prompt-governance or reusable-execution milestone yet
+- not silent artifact mutation
+- not artifact-centered replacement of run truth
+
+Exit signal:
+
+`R4` becomes the bridge out of transcript gravity while preserving one governed knowledgebase and one proposal-first continuity model.
+
+### R5 Prompt Studio
+
+User promise: prompt artifacts and model adaptations become governed reusable assets with lineage.
+
+Knowledgebase obligations at this stage:
+
+- prompt assets read shared memory and canon through explicit lineage-bearing references
+- staleness and dependency behavior are visible when accepted knowledge changes
+- model-profile and adaptation behavior stays part of governed substrate rather than hidden provider lore
+- prompt assets do not become a second memory store
+
+Package-maturity posture that matters most here:
+
+- `pkg.model-gateway` -> `M4`
+
+Intentional deferrals and refusals:
+
+- not governed applet execution yet
+- not prompt-side shadow canon
+- not prompt cards acting as substitutes for protocol or applet semantics
+
+Exit signal:
+
+Prompt artifacts can consume shared knowledge truth without replacing it or creating private prompt memory.
+
+### R6 Governed Agent / Applet Chat
+
+User promise: reusable execution can operate under explicit policy, verifier, and authority constraints instead of theater about autonomous agents.
+
+Knowledgebase obligations at this stage:
+
+- reusable execution receives explicit memory policy, contradiction guards, verifier packs, and queue routing
+- background or triggered work may observe and propose knowledge changes, but may not silently apply them
+- applets and workflows stay on shared truth and shared governance rather than inventing a private learning ontology
+
+Package-maturity posture that matters most here:
+
+- `pkg.tool-gateway-sandbox` -> `M4`
+
+Intentional deferrals and refusals:
+
+- not commissioning bridge yet
+- not hidden autonomy widening
+- not applet-private memory semantics
+
+Exit signal:
+
+Canon can safely let governed reusable execution participate in learning while preserving proposal-first mutation and shared truth ownership.
+
+### R7 Commissioning Bridge
+
+User promise: serious consequential work becomes explicit commissioning with authority, proof, delta, writeback, and handoff-grade continuity.
+
+Knowledgebase obligations at this stage:
+
+- preflight shows which memory and canon refs matter, under what authority they were accepted, and what review lineage governs them
+- commissioned work preserves knowledge participation through proof ledger, delta inspection, and writeback review surfaces
+- handoff payloads carry shared refs and authority lineage directly so Task Studio inherits meaning without ontology translation
+- commissioning stays explicit enough that this remains the final chat-native bridge rather than a chat-private branch of the platform
+
+Package-maturity posture that matters most here:
+
+- `pkg.environment-control` -> `M4`
+- `pkg.monitor-inspect` -> `M4`
+
+Intentional deferrals and refusals:
+
+- not a Task Studio rewrite
+- not chat-private commissioning semantics
+- not skipped preflight, authority review, or writeback lineage
+
+Exit signal:
+
+By `R7`, Canon can hand knowledge-bearing commissioned work into Task Studio as a projection change rather than a substrate rewrite.

--- a/canon-knowledgebase/canon-phase-4-plus-plan.md
+++ b/canon-knowledgebase/canon-phase-4-plus-plan.md
@@ -11,12 +11,15 @@
   - `canon-ref:dev/kb/canon-knowledgebase-layer-rollout-plan`
 - preserves_as_historical_support:
   - `canon-ref:dev/kb/canon-knowledgebase-layer-rollout-plan`
+  - `canon-ref:dev/kb/canon-phase-4-plus-plan-completed-steps-history`
   - `canon-ref:dev/kb/p00-architecture-delta`
   - `canon-ref:dev/kb/p01-shared-environment-knowledge-objects`
   - `canon-ref:dev/kb/p02-storage-and-query-lanes`
   - `canon-ref:dev/kb/p03-governance-and-event-spine-integration`
   - `canon-ref:dev/kb/p04-engine-seam-tightening`
   - `canon-ref:dev/kb/p05-compiler-injection-and-replay-basis`
+- defers_to_for_stage_authority:
+  - `canon-ref:dev/kb/canon-phase-4-plus-plan-stage-plan`
 - primary_source_basis:
   - `canon-ref:dev/ref/original-papers/chat-native-release-plan`
   - `https://github.com/SaintFreddy/Canon/blob/main/docs/control-plane/releases/chat-native-milestone-architecture-plan/phase-4-release-milestone-architecture-plan.md`
@@ -53,69 +56,30 @@ The registry normalizes local Canon language, but it does not override higher-au
 
 ## Current Plan Steps
 
-1. `complete` — cross-repo search and impact map.
-   - Objective: search the local workspace, `agentic-engine`, and `github.com/SaintFreddy/Canon` thoroughly enough to identify stale authority references, likely upstream update surfaces, and whether any local engine docs still point at the old packet authority.
-   - Completion signal: the workspace has a durable impact map, `agentic-engine` has been checked for local old-plan references, and the likely upstream Canon doc surfaces are named.
-2. `complete` — local authority and terminology sync.
-   - Objective: preserve historical rollout materials, promote the plan as the default active authority, and normalize local shorthand so future sessions can say `the plan` without ambiguity.
-   - Completion signal: the registry defines `plan` and `the plan`, the recovery files point at the plan, and historical scaffolding remains demoted rather than deleted.
-3. `complete` — upstream Canon Tier 1 authority sync.
-   - Objective: update the upstream milestone architecture plan, maturity matrix, Platform Gate spec, and context-compiler topology so they absorb the knowledgebase convergence path into the main release story without deleting history.
-   - Completion signal: upstream Tier 1 authority docs no longer imply the pre-sync story is still complete, and they explicitly preserve historical continuity while promoting the current authority.
-4. `complete` — upstream Canon downstream surface sync.
-   - Objective: update the affected downstream release packs, handoff surfaces, master-plan or carry-forward surfaces, and implementation blueprints so they inherit the promoted authority instead of stale pre-sync assumptions.
-   - Completion signal: the likely impacted R1, R2, R3, and R7 surfaces, plus any control-plane carry-forward surfaces, align to the promoted upstream authority.
-5. `complete` — local recovery recheck after upstream sync.
-   - Objective: recheck the local workspace after upstream changes land so fresh sessions can reopen the plan, understand the active step, and continue without chat memory or stale references.
-   - Completion signal: local recovery files, tracker state, and historical demotion notes still match the promoted upstream authority.
-6. `complete` — post-sync execution-plan commitment.
-   - Objective: turn the completed sync state plus the language-query memo into one explicit post-sync execution checkpoint so ordinary baton continuation can resume without guessing a restart point.
-   - Completion signal: this plan names the exact next bounded execution step, read boundary, excluded boundary, completion signal, verification surface, and reopen rule.
-7. `complete` — `PG-1` Platform Gate engine seam checkpoint and gap map.
-   - Objective: restart execution from the engine-owned seam by checking the current `agentic-engine` boundary docs, compiler surfaces, replay surfaces, and export contract against the Platform Gate knowledgebase obligations without importing shared-environment or app semantics into Layer 1.
-   - Completion signal: a durable checkpoint records which Platform Gate seam obligations are already satisfied in `agentic-engine`, which are still missing, and the smallest next implementation slice that stays inside engine boundaries.
-8. `complete` — `PG-2` frozen knowledge participation basis contract and wiring.
-   - Objective: harden the engine-owned seam by adding a first-class frozen knowledge participation basis for the memory and accepted-knowledge lanes in the compiled context and compile/report path without widening into shared-environment object or governance semantics.
-   - Completion signal: `agentic-engine` exposes a first-class knowledge participation basis for memory and accepted knowledge, the compiler populates it from current lane decisions, the run executor emits a compact basis summary, and the export contract matches the shipped surface.
-9. `complete` — `PG-3` authoritative knowledge-lane ref passthrough.
-   - Objective: harden the engine-owned seam by adding optional opaque authoritative refs to `MemoryObject` and `AcceptedKnowledgeObject`, preserving them into compiler `candidateRef` outputs and frozen knowledge-participation artifacts without widening into shared-environment object, governance, or stage-order semantics.
-   - Completion signal: memory and accepted-knowledge inputs accept optional authoritative refs, the compiler preserves them for included and excluded lane decisions, frozen knowledge-participation artifacts preserve them, and legacy synthesized refs remain only as fallback for callers that do not supply the new refs.
-10. `complete` — `PG-4` knowledge-lane admission projection seam.
-   - Objective: harden the engine-owned seam by adding optional explicit admission projections for memory and accepted-knowledge candidates so compiler admission can honor host-provided lane decisions before falling back to legacy engine-local lifecycle fields, without widening into shared-environment governance semantics or changing queue order in this slice.
-   - Completion signal: the compiler accepts optional admission projections for the memory and accepted-knowledge lanes, applies them before legacy lifecycle fallback, keeps report reasoning explicit about projection-versus-fallback decisions, and leaves the current accepted-knowledge-before-memory queue order unchanged in this slice.
-11. `complete` — `PG-5` memory-before-canon compiler staging.
-   - Objective: harden the engine-owned seam by making compiler staging budget memory before accepted knowledge while keeping the new projection-first admission seam, the existing frozen reporting path, and the legacy lifecycle fallback behavior unchanged in this slice.
-   - Completion signal: memory candidates budget before accepted-knowledge candidates under tight budget pressure, projection-first admission remains in front of legacy fallback, and the existing compilation report plus knowledge-participation basis surfaces remain the reporting path for this slice.
-12. `complete` — `PG-6` legacy knowledge-lane fallback isolation.
-   - Objective: harden the engine-owned seam by isolating legacy `memory.status`, `knowledge.challengeState`, and `validityBounds` fallback behind explicit compiler-local lane-admission helpers while keeping projection-first admission, memory-before-canon staging, and the existing frozen reporting path unchanged in this slice.
-   - Completion signal: compiler admission resolves through explicit projection-first helpers with localized legacy fallback per knowledge lane, no-projection behavior remains identical to the current fallback behavior, memory still budgets before accepted knowledge, and the existing compilation report plus knowledge-participation basis surfaces remain the reporting path.
-13. `complete` — post-evidence compiler stage-order correction.
-   - Objective: finish the inherited explicit stage model by budgeting optional evidence before the memory and accepted-knowledge lanes while keeping projection-first admission, localized legacy fallback, memory-before-canon ordering inside the knowledge lanes, and the existing frozen reporting path unchanged.
-   - Completion signal: all evidence candidates budget before memory and accepted knowledge, memory still budgets before accepted knowledge, and regression coverage proves the `evidence -> memory -> canon` order under tight budget pressure.
-14. `complete` — post-reopen host-projection lane-authority checkpoint.
-   - Objective: confirm the published host-projection authority promotion at `fafd681`, confirm the reopen checklist passes against published Canon authority, and use that authority to choose the smallest next engine-owned seam slice without starting implementation in the same step.
-   - Completion signal: `canon-ref:dev/kb/post-reopen-host-projection-lane-authority-checkpoint` records the exact still-open engine contradiction, the exact next engine slice, the read boundary, the excluded boundary, and the verification surface for the next session.
-15. `complete` — post-reopen lane-level host-projection authority implementation.
-   - Objective: implement the selected engine-owned seam so supplied memory and accepted-knowledge lane bags become authoritative per lane, fallback remains allowed only when a lane is absent, and the frozen knowledge-participation basis preserves lane input state without widening into replay, diff, or broader lifecycle retirement.
-   - Completion signal: `ContextCompilerPipeline` no longer falls back candidate-by-candidate inside supplied knowledge-lane bags, `RunExecutor` preserves the lane contract into compiler input, frozen knowledge participation preserves lane `inputState`, and `corepack pnpm typecheck` plus `corepack pnpm test` pass in `agentic-engine`.
-16. `complete` — post-reopen ref-first host-projection consumption.
-   - Objective: tighten the reopened host-projection seam so supplied memory and accepted-knowledge lane inputs resolve by authoritative candidate ref while tolerating existing engine-local ID keyed callers as compatibility fallback for the already-shipped projection seam, without changing lane-authority semantics, stage order, or broader lifecycle behavior.
-   - Completion signal: compiler admission resolves supplied lane entries by authoritative `candidateRef` first, targeted compiler and run-executor regressions prove the ref-keyed path, `contracts/exports.json` requires no edit, and `corepack pnpm typecheck` plus `corepack pnpm test` pass in `agentic-engine`.
-17. `complete` — post-reopen accepted-knowledge lane metadata passthrough.
-   - Objective: preserve canon-lane optional `mode` and optional validity summary through compiler normalization, compiled context, and deterministic frozen reporting surfaces while leaving lane-authority semantics, ref-first candidate lookup, absent-lane fallback, compact event reporting, and `evidence -> memory -> canon` order unchanged.
-   - Completion signal: accepted-knowledge lane metadata survives the compiled context and frozen snapshot seam, targeted core/compiler/snapshot/run-executor regressions prove the passthrough, `contracts/exports.json` requires no edit, and `corepack pnpm typecheck` plus `corepack pnpm test` pass in `agentic-engine`.
-18. `complete` — post-reopen frozen-posture replay/audit sufficiency checkpoint.
-   - Objective: inspect the now-frozen canon-lane reporting seam against published Canon authority and decide whether the current compiled-context and deterministic snapshot posture is already sufficient for later replay or audit consumers, without widening into replay, diff, compact event redesign, or broader schema work in the same step.
-   - Completion signal: durable state records the accepted-knowledge metadata passthrough slice as complete locally, confirms that the reopened engine seam is locally closed because the frozen context boundary already preserves the Canon-named lane posture, and records that no additional engine-owned reporting slice is currently named by published Canon authority.
-19. `complete` — post-forensic Phase 6 boundary correction.
-   - Objective: inspect the accepted R1 release contract, accepted Phase 6 R1 blueprint, accepted Phase 6 packet index, accepted current-state and repo-boundary authority, and the local Phase 6 continuation chain closely enough to determine whether any higher-authority Canon change actually reopened post-Platform-Gate implementation.
-   - Completion signal: durable state records that accepted Phase 6 materials model future roots and packet order under `Canon`, that accepted Canon authority now states explicitly that this modeling does not by itself authorize local implementation continuation, that the 2026-04-18 move into Phase 6 packet execution is preserved as a local inference error rather than a new higher-authority reopen event, and that the live next-step boundary returns to stop unless later accepted Canon authority, a cited contradiction, or an explicitly chosen different bounded task says otherwise.
-20. `complete` — audit-cited-contradiction reopen gate.
-   - Objective: absorb the 2026-04-18 agentic-engine audit as a cited contradiction event and record the plan-owner decisions needed before ordinary baton continuation can resume.
-   - Input basis: `AGENTIC_ENGINE_AUDIT_LOG.md` (506 findings: 15 CRITICAL, 130 HIGH, 208 MEDIUM, 123 LOW, 30 INFO) and `CANON_PLAN_IMPACT_REPORT.md` (74 of 145 CRITICAL+HIGH findings requiring plan-owner action).
-   - Completion signal: a durable plan-owner decision record exists for each of the twelve decisions in `CANON_PLAN_IMPACT_REPORT.md` Section 6, the Platform Gate truth-status is explicitly chosen (reopen vs retain `passed` with audit-aware footnotes), and `canon-ref:dev/kb/post-reopen-frozen-posture-replay-audit-sufficiency-checkpoint` is formally superseded by `canon-ref:dev/kb/post-reopen-audit-cited-contradiction-checkpoint`.
-   - Explicit non-goals: no `agentic-engine` code remediation inside this step; no plan-prose rewrite beyond the decision record itself; no attempt to decide plan-owner choices autonomously.
-   - Closure (2026-04-24): all three completion signals satisfied. (i) Twelve plan-owner decision records exist under `canon-knowledgebase/post-reopen-decisions/` — condition-a, condition-b, condition-c, condition-d, condition-e-engine-version, condition-e-license, condition-f, condition-g, condition-h, condition-i, condition-j, and the frozenat-hash-inclusion sub-decision. (ii) Platform Gate truth-status explicitly reopened per DEC-RO-0f (Option A — formal reopen with PG-01.1 / PG-07.1 / PG-10.1 sub-gates). (iii) The frozen-posture-replay-audit-sufficiency checkpoint is formally superseded by the post-reopen-audit-cited-contradiction checkpoint per DEC-RO-0i. Additionally, the full remediation wave authorized by DEC-RO-01 through DEC-RO-05 has been EXECUTED as of 2026-04-24: 21 autonomous droid PRs merged across `SaintFreddy/Canon` (10), `SaintFreddy/agentic-engine` (8), `SaintFreddy/canon-apps`, `SaintFreddy/shared-environment`, and `SaintFreddy/agentic-engine-history` (1 LICENSE each). Quarantined `Canon/packages/`, `Canon/services/`, `Canon/workers/` pre-reopen draft state is archived to `docs/control-plane/archive/quarantine-pre-reopen/` per DEC-RO-05 and removed from the local workspace. The carry-forward chain CF-0089 through CF-0096 records the full closure. Ordinary baton continuation is cleared to resume when the plan-owner names the next bounded step from the stage plan below.
+All 20 bounded steps are `complete`. The compact step-status table below is the live recovery surface; the full `Objective` / `Completion signal` / (where applicable) `Closure` narrative for each step lives in `canon-ref:dev/kb/canon-phase-4-plus-plan-completed-steps-history`.
+
+| # | Label | Status |
+| --- | --- | --- |
+| 1 | cross-repo search and impact map | `complete` |
+| 2 | local authority and terminology sync | `complete` |
+| 3 | upstream Canon Tier 1 authority sync | `complete` |
+| 4 | upstream Canon downstream surface sync | `complete` |
+| 5 | local recovery recheck after upstream sync | `complete` |
+| 6 | post-sync execution-plan commitment | `complete` |
+| 7 | `PG-1` Platform Gate engine seam checkpoint and gap map | `complete` |
+| 8 | `PG-2` frozen knowledge participation basis contract and wiring | `complete` |
+| 9 | `PG-3` authoritative knowledge-lane ref passthrough | `complete` |
+| 10 | `PG-4` knowledge-lane admission projection seam | `complete` |
+| 11 | `PG-5` memory-before-canon compiler staging | `complete` |
+| 12 | `PG-6` legacy knowledge-lane fallback isolation | `complete` |
+| 13 | post-evidence compiler stage-order correction | `complete` |
+| 14 | post-reopen host-projection lane-authority checkpoint | `complete` |
+| 15 | post-reopen lane-level host-projection authority implementation | `complete` |
+| 16 | post-reopen ref-first host-projection consumption | `complete` |
+| 17 | post-reopen accepted-knowledge lane metadata passthrough | `complete` |
+| 18 | post-reopen frozen-posture replay/audit sufficiency checkpoint | `complete` |
+| 19 | post-forensic Phase 6 boundary correction | `complete` |
+| 20 | audit-cited-contradiction reopen gate (closed 2026-04-24 via `CF-0097`; downstream propagation via `CF-0098`..`CF-0100`; live closure evidence duplicated in `Committed Post-Sync Execution Boundary` below) | `complete` |
 
 Post-`PG-6` correction closure note: the bounded stage-order correction is now landed locally. `ContextCompilerPipeline` budgets optional evidence before memory and accepted knowledge, targeted regression coverage proves the inherited `evidence -> memory -> canon -> freeze` order under tight budget pressure, and broad lifecycle-fallback retirement remains deferred until accepted explicit host-projection contract authority exists.
 
@@ -204,218 +168,9 @@ Use `canon-ref:dev/kb/identity/canon-canon-registry` to normalize those legacy p
 
 ## Stage Plan
 
-### Platform Gate
+The full release-stage authority for Platform Gate + `R1`..`R7` (architecture or user promise, knowledgebase obligations, package-maturity posture, intentional deferrals and refusals, and exit signal per stage) lives at `canon-ref:dev/kb/canon-phase-4-plus-plan-stage-plan`.
 
-Architecture goal: prove the substrate is real enough that every public release can inherit knowledge participation without pretending transcript continuity is truth.
-
-Knowledgebase obligations at this stage:
-
-- memory and canon injection are real engine seams with authoritative refs and frozen replay basis behavior
-- append-only knowledge observation, proposal, decision, and state-transition events are real shared-environment substrate
-- proposal, review, approval, and apply paths for memory and canon are executable on real paths, even if still internal-facing
-- passive capture starts as scoped observation intake and proposal substrate, not as user-facing autonomous memory magic
-- operator and audit surfaces can show what knowledge participated in a run and why it was admitted or blocked
-
-Package-maturity posture that matters most here:
-
-- all package areas must already be real at `M1`
-- `pkg.context-compiler`, `pkg.shared-object-api`, `pkg.event-provenance-spine`, and `pkg.review-writeback` must be real enough that later stages inherit them instead of debating their existence
-
-Intentional deferrals and refusals:
-
-- no public learning product promise yet
-- no transcript-private memory behavior
-- no branch, artifact, prompt, applet, or commissioning semantics smuggled in early
-- no silent background promotion of candidate learning
-
-Exit signal:
-
-`R1` can honestly expose bounded runs with explicit knowledge participation because the substrate beneath that story is already real.
-
-### R1 Transcript Chat
-
-User promise: this still feels familiar, but each answer is a bounded run with explicit grounding rather than transcript-owned truth.
-
-Knowledgebase obligations at this stage:
-
-- disclose when memory or canon participated in a run
-- preserve compact visibility into included and excluded knowledge basis records
-- keep candidate learning internal or visibly marked as suggestion-only rather than injecting it by default
-- keep early reviewer and operator surfaces honest even if full governance UX is not yet public-facing
-
-Package-maturity posture that matters most here:
-
-- `pkg.environment-control` -> `M3`
-- `pkg.context-compiler` -> `M3`
-- `pkg.shared-object-api`, `pkg.model-gateway`, `pkg.event-provenance-spine`, and `pkg.monitor-inspect` -> `M2`
-
-Intentional deferrals and refusals:
-
-- not full context editing
-- not artifact-centered continuity
-- not hidden memory accumulation
-- not governed reusable execution
-
-Exit signal:
-
-Users can see that knowledge participation is real and explicit, while the product still avoids pretending that `R1` offers full memory governance.
-
-### R2 Context Chat
-
-User promise: context control becomes explicit and replayable instead of being tucked behind invisible defaults.
-
-Knowledgebase obligations at this stage:
-
-- include, exclude, pin, and challenge controls operate over active memory and canon participation
-- the system can show why a memory or canon record was included, excluded, blocked, previewed, or constrained
-- user corrections can open proposal-bearing flows without collapsing directly into accepted truth
-- passive capture and early distillation stay proposal-first and visibly scoped
-
-Package-maturity posture that matters most here:
-
-- `pkg.context-compiler` -> `M4`
-- `pkg.shared-object-api` -> `M3`
-- `pkg.event-provenance-spine` -> `M3`
-- `pkg.monitor-inspect` -> `M3`
-- `pkg.replay-compare` -> `M2`
-
-Intentional deferrals and refusals:
-
-- not branch-map semantics yet
-- not artifact-governance center of gravity yet
-- not fake context control that only edits sidebars while hidden defaults continue elsewhere
-
-Exit signal:
-
-`R2` can expose real pack control over knowledge participation without widening into fake branching or early artifact governance.
-
-### R3 Branch / Visual Thinker
-
-User promise: branches, replay, compare, and mode projections can vary assumptions without breaking run truth.
-
-Knowledgebase obligations at this stage:
-
-- exact replay reuses frozen knowledge refs from the original basis
-- altered replay and compare report explicit knowledge-basis diffs instead of silently rerunning mutable discovery
-- suspensions, supersessions, and branch-local differences stay queryable and explainable
-- merge and conflict surfaces treat knowledge disagreements as governed state, not transcript drift
-
-Package-maturity posture that matters most here:
-
-- `pkg.event-provenance-spine` -> `M4`
-- `pkg.replay-compare` -> `M4`
-- `pkg.review-writeback` -> `M2`
-
-Intentional deferrals and refusals:
-
-- not artifact review center yet
-- not prompt or applet infrastructure milestone
-- not transcript cloning presented as branching
-
-Exit signal:
-
-Canon can distinguish same-basis replay from changed-basis replay without hand-waving over knowledge lineage.
-
-### R4 Artifact Workspace
-
-User promise: continuity shifts from transcript gravity to artifacts, proposals, reviews, approvals, and durable run-linked work.
-
-Knowledgebase obligations at this stage:
-
-- artifact-linked knowledge proposals become the main durable promotion path
-- objections, alternatives, suspensions, and supersessions stay first-class shared-environment governance records
-- accepted memory and canon remain tied back to run, proof, delta, artifact, and approval lineage
-- artifact-centered continuity inherits the same knowledgebase rather than inventing a new truth model
-
-Package-maturity posture that matters most here:
-
-- `pkg.shared-object-api` -> `M4`
-- `pkg.review-writeback` -> `M4`
-
-Intentional deferrals and refusals:
-
-- not prompt-governance or reusable-execution milestone yet
-- not silent artifact mutation
-- not artifact-centered replacement of run truth
-
-Exit signal:
-
-`R4` becomes the bridge out of transcript gravity while preserving one governed knowledgebase and one proposal-first continuity model.
-
-### R5 Prompt Studio
-
-User promise: prompt artifacts and model adaptations become governed reusable assets with lineage.
-
-Knowledgebase obligations at this stage:
-
-- prompt assets read shared memory and canon through explicit lineage-bearing references
-- staleness and dependency behavior are visible when accepted knowledge changes
-- model-profile and adaptation behavior stays part of governed substrate rather than hidden provider lore
-- prompt assets do not become a second memory store
-
-Package-maturity posture that matters most here:
-
-- `pkg.model-gateway` -> `M4`
-
-Intentional deferrals and refusals:
-
-- not governed applet execution yet
-- not prompt-side shadow canon
-- not prompt cards acting as substitutes for protocol or applet semantics
-
-Exit signal:
-
-Prompt artifacts can consume shared knowledge truth without replacing it or creating private prompt memory.
-
-### R6 Governed Agent / Applet Chat
-
-User promise: reusable execution can operate under explicit policy, verifier, and authority constraints instead of theater about autonomous agents.
-
-Knowledgebase obligations at this stage:
-
-- reusable execution receives explicit memory policy, contradiction guards, verifier packs, and queue routing
-- background or triggered work may observe and propose knowledge changes, but may not silently apply them
-- applets and workflows stay on shared truth and shared governance rather than inventing a private learning ontology
-
-Package-maturity posture that matters most here:
-
-- `pkg.tool-gateway-sandbox` -> `M4`
-
-Intentional deferrals and refusals:
-
-- not commissioning bridge yet
-- not hidden autonomy widening
-- not applet-private memory semantics
-
-Exit signal:
-
-Canon can safely let governed reusable execution participate in learning while preserving proposal-first mutation and shared truth ownership.
-
-### R7 Commissioning Bridge
-
-User promise: serious consequential work becomes explicit commissioning with authority, proof, delta, writeback, and handoff-grade continuity.
-
-Knowledgebase obligations at this stage:
-
-- preflight shows which memory and canon refs matter, under what authority they were accepted, and what review lineage governs them
-- commissioned work preserves knowledge participation through proof ledger, delta inspection, and writeback review surfaces
-- handoff payloads carry shared refs and authority lineage directly so Task Studio inherits meaning without ontology translation
-- commissioning stays explicit enough that this remains the final chat-native bridge rather than a chat-private branch of the platform
-
-Package-maturity posture that matters most here:
-
-- `pkg.environment-control` -> `M4`
-- `pkg.monitor-inspect` -> `M4`
-
-Intentional deferrals and refusals:
-
-- not a Task Studio rewrite
-- not chat-private commissioning semantics
-- not skipped preflight, authority review, or writeback lineage
-
-Exit signal:
-
-By `R7`, Canon can hand knowledge-bearing commissioned work into Task Studio as a projection change rather than a substrate rewrite.
+Open that file only when a plan-owner-selected release stage becomes the active bounded step. The `Cross-Stage Guardrails` block below remains the live list of rules that apply across every stage, regardless of which stage is currently in focus.
 
 ## Cross-Stage Guardrails
 


### PR DESCRIPTION
## Summary

Workspace-optimization pass on Canon Dev active authority file `canon-knowledgebase/canon-phase-4-plus-plan.md`. Moves the full release-stage authority (Platform Gate + R1..R7, ~214 lines) out of the hot recovery surface into a new sibling file, leaving a compact pointer in the hot plan plus the live `Cross-Stage Guardrails` block inline.

Hot plan: **418 → 211 lines (49% shrink)** on fresh-session read cost.

## New file: `canon-knowledgebase/canon-phase-4-plus-plan-stage-plan.md` (249 lines)

Preserves the full release-stage authority verbatim for all 8 stages:

- Platform Gate
- R1 Transcript Chat
- R2 Context Chat
- R3 Branch / Visual Thinker
- R4 Artifact Workspace
- R5 Prompt Studio
- R6 Governed Agent / Applet Chat
- R7 Commissioning Bridge

Each stage keeps the same five-field shape: architecture or user promise, knowledgebase obligations, package-maturity posture, intentional deferrals and refusals, exit signal.

## Hot plan changes

`## Stage Plan` section becomes a 3-line pointer:

- names the new file via `canon-ref:dev/kb/canon-phase-4-plus-plan-stage-plan`
- says to open that file only when a plan-owner-selected stage becomes the active bounded step
- notes the live `Cross-Stage Guardrails` block below remains applicable across every stage regardless of which stage is currently in focus

`## Cross-Stage Guardrails` (8 guardrails), `## Immediate Next Checkpoint`, and `## Historical Boundary` all stay in the hot plan since they are live content that applies across the full lifecycle.

## Canon-ref + Plan Contract updates

- Canon Dev `canon-ref-registry.json` registers `dev/kb/canon-phase-4-plus-plan-stage-plan` resolving to the new file.
- Canon Dev Plan Contract adds a new `defers_to_for_stage_authority` field (distinguished from `preserves_as_historical_support` because the content is still forward-looking release authority, not historical scaffolding).

## Durable state

Unchanged: all 20 steps still `complete`, baton still `ready`, next bounded step still intentionally unassigned. This PR changes the documentation of state, not state itself.

## Verification

- Zero net new `canon-ref` validator warnings. Pre-existing count held steady at 51.
- Full release-stage authority preserved behind one canon-ref token.

## Related

- Third PR in the 2026-04-24 Canon Dev workspace-optimization session.
- Follows the same reconciliation pattern as #45 (canon_tasks.md sync) and #46 (canon-phase-4-plus-plan.md completed-steps history demotion).